### PR TITLE
Improves mapping of constants in expressions.

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
@@ -11,8 +11,8 @@ namespace AutoMapper.Extensions.ExpressionMapping
 {
     public class MapIncludesVisitor : XpressionMapperVisitor
     {
-        public MapIncludesVisitor(IConfigurationProvider configurationProvider, Dictionary<Type, Type> typeMappings)
-            : base(configurationProvider, typeMappings)
+        public MapIncludesVisitor(IMapper mapper, IConfigurationProvider configurationProvider, Dictionary<Type, Type> typeMappings)
+            : base(mapper, configurationProvider, typeMappings)
         {
         }
 

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using static System.Linq.Expressions.Expression;
 using System.Reflection;
 using AutoMapper.Mappers.Internal;
+using AutoMapper.Internal;
 
 namespace AutoMapper.Extensions.ExpressionMapping
 {
@@ -21,21 +22,59 @@ namespace AutoMapper.Extensions.ExpressionMapping
             where TDestDelegate : LambdaExpression
         {
             if (expression == null)
-                return default(TDestDelegate);
+                return default;
 
-            var typeSourceFunc = expression.GetType().GetGenericArguments()[0];
-            var typeDestFunc = typeof(TDestDelegate).GetGenericArguments()[0];
-
-            var typeMappings = new Dictionary<Type, Type>()
-                                            .AddTypeMappingsFromDelegates(typeSourceFunc, typeDestFunc);
-
-            var visitor = new XpressionMapperVisitor(mapper == null ? Mapper.Configuration : mapper.ConfigurationProvider, typeMappings);
-            var remappedBody = visitor.Visit(expression.Body);
-            if (remappedBody == null)
-                throw new InvalidOperationException(Resource.cantRemapExpression);
-
-            return (TDestDelegate)Lambda(typeDestFunc, remappedBody, expression.GetDestinationParameterExpressions(visitor.InfoDictionary, typeMappings));
+            return mapper.MapExpression<TDestDelegate>
+            (
+                expression, 
+                (config, mappings) => new XpressionMapperVisitor(mapper, config, mappings)
+            );
         }
+
+        private static TDestDelegate MapExpression<TDestDelegate>(this IMapper mapper, LambdaExpression expression, Func<IConfigurationProvider, Dictionary<Type, Type>, XpressionMapperVisitor> getVisitor)
+            where TDestDelegate : LambdaExpression
+        {
+            return MapExpression<TDestDelegate>
+            (
+                mapper ?? Mapper.Instance,
+                mapper == null ? Mapper.Configuration : mapper.ConfigurationProvider,
+                expression,
+                expression.GetType().GetGenericArguments()[0],
+                typeof(TDestDelegate).GetGenericArguments()[0],
+                getVisitor
+            );
+        }
+
+        private static TDestDelegate MapExpression<TDestDelegate>(IMapper mapper,
+            IConfigurationProvider configurationProvider,
+            LambdaExpression expression,
+            Type typeSourceFunc,
+            Type typeDestFunc,
+            Func<IConfigurationProvider, Dictionary<Type, Type>, XpressionMapperVisitor> getVisitor)
+            where TDestDelegate : LambdaExpression
+        {
+            return CreateVisitor(new Dictionary<Type, Type>().AddTypeMappingsFromDelegates(configurationProvider, typeSourceFunc, typeDestFunc));
+
+            TDestDelegate CreateVisitor(Dictionary<Type, Type> typeMappings)
+                => MapBody(typeMappings, getVisitor(configurationProvider, typeMappings));
+
+            TDestDelegate MapBody(Dictionary<Type, Type> typeMappings, XpressionMapperVisitor visitor)
+                => GetLambda(typeMappings, visitor, visitor.Visit(expression.Body));
+
+            TDestDelegate GetLambda(Dictionary<Type, Type> typeMappings, XpressionMapperVisitor visitor, Expression remappedBody)
+            {
+                if (remappedBody == null)
+                    throw new InvalidOperationException(Resource.cantRemapExpression);
+
+                return (TDestDelegate)Lambda
+                (
+                    typeDestFunc,
+                    ExpressionFactory.ToType(remappedBody, typeDestFunc.GetGenericArguments().Last()),
+                    expression.GetDestinationParameterExpressions(visitor.InfoDictionary, typeMappings)
+                );
+            }
+        }
+
 
         /// <summary>
         /// Maps an expression given a dictionary of types where the source type is the key and the destination type is the value.
@@ -47,7 +86,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <returns></returns>
         public static TDestDelegate MapExpression<TSourceDelegate, TDestDelegate>(this IMapper mapper, TSourceDelegate expression)
             where TSourceDelegate : LambdaExpression
-            where TDestDelegate : LambdaExpression 
+            where TDestDelegate : LambdaExpression
             => mapper.MapExpression<TDestDelegate>(expression);
 
         /// <summary>
@@ -61,20 +100,13 @@ namespace AutoMapper.Extensions.ExpressionMapping
             where TDestDelegate : LambdaExpression
         {
             if (expression == null)
-                return null;
+                return default;
 
-            var typeSourceFunc = expression.GetType().GetGenericArguments()[0];
-            var typeDestFunc = typeof(TDestDelegate).GetGenericArguments()[0];
-
-            var typeMappings = new Dictionary<Type, Type>()
-                                            .AddTypeMappingsFromDelegates(typeSourceFunc, typeDestFunc);
-
-            XpressionMapperVisitor visitor = new MapIncludesVisitor(mapper == null ? Mapper.Configuration : mapper.ConfigurationProvider, typeMappings);
-            var remappedBody = visitor.Visit(expression.Body);
-            if (remappedBody == null)
-                throw new InvalidOperationException(Resource.cantRemapExpression);
-
-            return (TDestDelegate)Lambda(typeDestFunc, remappedBody, expression.GetDestinationParameterExpressions(visitor.InfoDictionary, typeMappings));
+            return mapper.MapExpression<TDestDelegate>
+            (
+                expression,
+                (config, mappings) => new MapIncludesVisitor(mapper, config, mappings)
+            );
         }
 
         /// <summary>
@@ -87,7 +119,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <returns></returns>
         public static TDestDelegate MapExpressionAsInclude<TSourceDelegate, TDestDelegate>(this IMapper mapper, TSourceDelegate expression)
             where TSourceDelegate : LambdaExpression
-            where TDestDelegate : LambdaExpression 
+            where TDestDelegate : LambdaExpression
             => mapper.MapExpressionAsInclude<TDestDelegate>(expression);
 
         /// <summary>
@@ -100,7 +132,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <returns></returns>
         public static ICollection<TDestDelegate> MapExpressionList<TSourceDelegate, TDestDelegate>(this IMapper mapper, ICollection<TSourceDelegate> collection)
             where TSourceDelegate : LambdaExpression
-            where TDestDelegate : LambdaExpression 
+            where TDestDelegate : LambdaExpression
             => collection?.Select(mapper.MapExpression<TSourceDelegate, TDestDelegate>).ToList();
 
         /// <summary>
@@ -111,7 +143,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <param name="collection"></param>
         /// <returns></returns>
         public static ICollection<TDestDelegate> MapExpressionList<TDestDelegate>(this IMapper mapper, IEnumerable<LambdaExpression> collection)
-            where TDestDelegate : LambdaExpression 
+            where TDestDelegate : LambdaExpression
             => collection?.Select(mapper.MapExpression<TDestDelegate>).ToList();
 
         /// <summary>
@@ -124,7 +156,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <returns></returns>
         public static ICollection<TDestDelegate> MapIncludesList<TSourceDelegate, TDestDelegate>(this IMapper mapper, ICollection<TSourceDelegate> collection)
             where TSourceDelegate : LambdaExpression
-            where TDestDelegate : LambdaExpression 
+            where TDestDelegate : LambdaExpression
             => collection?.Select(mapper.MapExpressionAsInclude<TSourceDelegate, TDestDelegate>).ToList();
 
         /// <summary>
@@ -135,7 +167,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <param name="collection"></param>
         /// <returns></returns>
         public static ICollection<TDestDelegate> MapIncludesList<TDestDelegate>(this IMapper mapper, IEnumerable<LambdaExpression> collection)
-            where TDestDelegate : LambdaExpression 
+            where TDestDelegate : LambdaExpression
             => collection?.Select(mapper.MapExpressionAsInclude<TDestDelegate>).ToList();
 
         /// <summary>
@@ -161,47 +193,37 @@ namespace AutoMapper.Extensions.ExpressionMapping
         /// <typeparam name="TSource"></typeparam>
         /// <typeparam name="TDest"></typeparam>
         /// <param name="typeMappings"></param>
+        /// <param name="configurationProvider"></param>
         /// <returns></returns>
-        public static Dictionary<Type, Type> AddTypeMapping<TSource, TDest>(this Dictionary<Type, Type> typeMappings)
+        public static Dictionary<Type, Type> AddTypeMapping<TSource, TDest>(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider)
             => typeMappings == null
                 ? throw new ArgumentException(Resource.typeMappingsDictionaryIsNull)
-                : typeMappings.AddTypeMapping(typeof(TSource), typeof(TDest));
+                : typeMappings.AddTypeMapping(configurationProvider, typeof(TSource), typeof(TDest));
 
         private static bool HasUnderlyingType(this Type type)
         {
             return (type.IsGenericType() && typeof(System.Collections.IEnumerable).IsAssignableFrom(type)) || type.IsArray;
         }
 
-        private static void AddUnderlyingTypes(this Dictionary<Type, Type> typeMappings, Type sourceType, Type destType)
+        private static void AddUnderlyingTypes(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, Type sourceType, Type destType)
         {
-            var sourceArguments = !sourceType.HasUnderlyingType()
-                                    ? new List<Type>()
-                                    : ElementTypeHelper.GetElementTypes(sourceType).ToList();
-
-            var destArguments = !destType.HasUnderlyingType()
-                                    ? new List<Type>()
-                                    : ElementTypeHelper.GetElementTypes(destType).ToList();
-
-            if (sourceArguments.Count != destArguments.Count)
-                throw new ArgumentException(Resource.invalidArgumentCount);
-
-            sourceArguments.Aggregate(typeMappings, (dic, next) =>
-            {
-                if (!dic.ContainsKey(next) && next != destArguments[sourceArguments.IndexOf(next)])
-                    dic.AddTypeMapping(next, destArguments[sourceArguments.IndexOf(next)]);
-
-                return dic;
-            });
+            typeMappings.DoAddTypeMappings
+            (
+                configurationProvider,
+                !sourceType.HasUnderlyingType() ? new List<Type>() : ElementTypeHelper.GetElementTypes(sourceType).ToList(),
+                !destType.HasUnderlyingType() ? new List<Type>() : ElementTypeHelper.GetElementTypes(destType).ToList()
+            );
         }
 
         /// <summary>
         /// Adds a new source and destination key-value pair to a dictionary of type mappings based on the arguments.
         /// </summary>
         /// <param name="typeMappings"></param>
+        /// <param name="configurationProvider"></param>
         /// <param name="sourceType"></param>
         /// <param name="destType"></param>
         /// <returns></returns>
-        public static Dictionary<Type, Type> AddTypeMapping(this Dictionary<Type, Type> typeMappings, Type sourceType, Type destType)
+        public static Dictionary<Type, Type> AddTypeMapping(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, Type sourceType, Type destType)
         {
             if (typeMappings == null)
                 throw new ArgumentException(Resource.typeMappingsDictionaryIsNull);
@@ -216,32 +238,75 @@ namespace AutoMapper.Extensions.ExpressionMapping
             {
                 typeMappings.Add(sourceType, destType);
                 if (typeof(Delegate).IsAssignableFrom(sourceType))
-                    typeMappings.AddTypeMappingsFromDelegates(sourceType, destType);
+                    typeMappings.AddTypeMappingsFromDelegates(configurationProvider, sourceType, destType);
                 else
-                    typeMappings.AddUnderlyingTypes(sourceType, destType);
+                {
+                    typeMappings.AddUnderlyingTypes(configurationProvider, sourceType, destType);
+                    typeMappings.FindChildPropertyTypeMaps(configurationProvider, sourceType, destType);
+                }
             }
 
             return typeMappings;
         }
 
-        private static Dictionary<Type, Type> AddTypeMappingsFromDelegates(this Dictionary<Type, Type> typeMappings, Type sourceType, Type destType)
+        private static Dictionary<Type, Type> AddTypeMappingsFromDelegates(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, Type sourceType, Type destType)
         {
             if (typeMappings == null)
                 throw new ArgumentException(Resource.typeMappingsDictionaryIsNull);
 
-            var sourceArguments = sourceType.GetGenericArguments().ToList();
-            var destArguments = destType.GetGenericArguments().ToList();
+            typeMappings.DoAddTypeMappings
+            (
+                configurationProvider,
+                sourceType.GetGenericArguments().ToList(),
+                destType.GetGenericArguments().ToList()
+            );
 
+            return typeMappings;
+        }
+
+        private static void DoAddTypeMappings(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, List<Type> sourceArguments, List<Type> destArguments)
+        {
             if (sourceArguments.Count != destArguments.Count)
                 throw new ArgumentException(Resource.invalidArgumentCount);
 
-            return sourceArguments.Aggregate(typeMappings, (dic, next) =>
+            for (int i = 0; i < sourceArguments.Count; i++)
             {
-                if (!dic.ContainsKey(next) && next != destArguments[sourceArguments.IndexOf(next)])
-                    dic.AddTypeMapping(next, destArguments[sourceArguments.IndexOf(next)]);
+                if (!typeMappings.ContainsKey(sourceArguments[i]) && sourceArguments[i] != destArguments[i])
+                    typeMappings.AddTypeMapping(configurationProvider, sourceArguments[i], destArguments[i]);
+            }
+        }
 
-                return dic;
-            });
+        private static void FindChildPropertyTypeMaps(this Dictionary<Type, Type> typeMappings, IConfigurationProvider ConfigurationProvider, Type source, Type dest)
+        {
+            //The destination becomes the source because to map a source expression to a destination expression,
+            //we need the expressions used to create the source from the destination
+            var typeMap = ConfigurationProvider.ResolveTypeMap(sourceType: dest, destinationType: source);
+
+            if (typeMap == null)
+                return;
+
+            FindMaps(typeMap.GetPropertyMaps().ToList());
+            void FindMaps(List<PropertyMap> maps)
+            {
+                foreach (PropertyMap pm in maps)
+                {
+                    if (pm.SourceMember == null)
+                        continue;
+
+                    AddChildMappings
+                    (
+                        source.GetFieldOrProperty(pm.DestinationProperty.Name).GetMemberType(),
+                        pm.SourceMember.GetMemberType()
+                    );
+                    void AddChildMappings(Type sourcePropertyType, Type destPropertyType)
+                    {
+                        if (sourcePropertyType.IsLiteralType() || destPropertyType.IsLiteralType())
+                            return;
+
+                        typeMappings.AddTypeMapping(ConfigurationProvider, sourcePropertyType, destPropertyType);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/AutoMapper.Extensions.ExpressionMapping/Resource.resx
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Resource.resx
@@ -125,7 +125,7 @@
     <value>Can't rempa expression</value>
   </data>
   <data name="expressionMapValueTypeMustMatchFormat" xml:space="preserve">
-    <value>The source and destination types must be the same for expression mapping between value types. Source Type: {0}, Source Description: {1}, Destination Type: {2}, Destination Property: {3}.</value>
+    <value>The source and destination types must be the same for expression mapping between literal types. Source Type: {0}, Source Description: {1}, Destination Type: {2}, Destination Property: {3}.</value>
     <comment>0=Source Type; 1=SourceDescription; 2=Destination Type; 3=Destination Property.</comment>
   </data>
   <data name="includeExpressionTooComplex" xml:space="preserve">

--- a/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
@@ -1,3 +1,4 @@
+using AutoMapper.Configuration.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -126,7 +127,35 @@ namespace AutoMapper
 
         public static bool IsValueType(this Type type) => type.GetTypeInfo().IsValueType;
 
-        public static bool IsLiteralType(this Type type) => type == typeof(string) || type.GetTypeInfo().IsValueType;
+        public static bool IsLiteralType(this Type type)
+        {
+            if (PrimitiveHelper.IsNullableType(type))
+                type = Nullable.GetUnderlyingType(type);
+
+            return LiteralTypes.Contains(type);
+        }
+
+        private static HashSet<Type> LiteralTypes => new HashSet<Type>(_literalTypes);
+
+        private static Type[] _literalTypes => new Type[] {
+                typeof(bool),
+                typeof(DateTime),
+                typeof(TimeSpan),
+                typeof(Guid),
+                typeof(decimal),
+                typeof(byte),
+                typeof(short),
+                typeof(int),
+                typeof(long),
+                typeof(float),
+                typeof(double),
+                typeof(char),
+                typeof(sbyte),
+                typeof(ushort),
+                typeof(uint),
+                typeof(ulong),
+                typeof(string)
+            };
 
         public static bool IsInstanceOfType(this Type type, object o) => o != null && type.GetTypeInfo().IsAssignableFrom(o.GetType().GetTypeInfo());
 

--- a/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
@@ -15,8 +15,9 @@ namespace AutoMapper.Extensions.ExpressionMapping
 {
     public class XpressionMapperVisitor : ExpressionVisitor
     {
-        public XpressionMapperVisitor(IConfigurationProvider configurationProvider, Dictionary<Type, Type> typeMappings)
+        public XpressionMapperVisitor(IMapper mapper, IConfigurationProvider configurationProvider, Dictionary<Type, Type> typeMappings)
         {
+            Mapper = mapper;
             TypeMappings = typeMappings;
             InfoDictionary = new MapperInfoDictionary(new ParameterExpressionEqualityComparer());
             ConfigurationProvider = configurationProvider;
@@ -27,6 +28,8 @@ namespace AutoMapper.Extensions.ExpressionMapping
         public Dictionary<Type, Type> TypeMappings { get; }
 
         protected IConfigurationProvider ConfigurationProvider { get; }
+
+        protected IMapper Mapper { get; }
 
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {
@@ -83,20 +86,43 @@ namespace AutoMapper.Extensions.ExpressionMapping
                     ? visitor.Visit(last.CustomExpression.Body.MemberAccesses(afterCustExpression))
                     : visitor.Visit(last.CustomExpression.Body);
 
-                TypeMappings.AddTypeMapping(node.Type, ex.Type);
+                this.TypeMappings.AddTypeMapping(ConfigurationProvider, node.Type, ex.Type);
                 return ex;
             }
             fullName = BuildFullName(propertyMapInfoList);
             var me = ExpressionFactory.MemberAccesses(fullName, InfoDictionary[parameterExpression].NewParameter);
 
-            TypeMappings.AddTypeMapping(node.Type, me.Type);
+            this.TypeMappings.AddTypeMapping(ConfigurationProvider, node.Type, me.Type);
             return me;
+        }
+
+        protected override Expression VisitUnary(UnaryExpression node)
+        {
+            switch (node.NodeType)
+            {
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    switch (node.Operand.NodeType)
+                    {
+                        case ExpressionType.Constant:
+                            return ProcessConstant((ConstantExpression)node.Operand);
+                        default:
+                            return base.VisitUnary(node);
+                    }
+                default:
+                    return base.VisitUnary(node);
+            }
+
+            Expression ProcessConstant(ConstantExpression operand)
+                                => this.TypeMappings.TryGetValue(operand.Type, out Type newType)
+                                    ? Expression.Constant(Mapper.Map(operand.Value, node.Type, newType), newType)
+                                    : base.VisitUnary(node);
         }
 
         protected override Expression VisitConstant(ConstantExpression node)
         {
-            if (TypeMappings.TryGetValue(node.Type, out Type newType))
-                return base.VisitConstant(Expression.Constant(node.Value, newType));
+            if (this.TypeMappings.TryGetValue(node.Type, out Type newType))
+                return base.VisitConstant(Expression.Constant(Mapper.Map(node.Value, node.Type, newType), newType));
 
             return base.VisitConstant(node);
         }
@@ -112,7 +138,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
             var listOfArgumentsForNewMethod = node.Arguments.Aggregate(new List<Expression>(), (lst, next) =>
             {
                 var mappedNext = ArgumentMapper.Create(this, next).MappedArgumentExpression;
-                TypeMappings.AddTypeMapping(next.Type, mappedNext.Type);
+                TypeMappings.AddTypeMapping(ConfigurationProvider, next.Type, mappedNext.Type);
 
                 lst.Add(mappedNext);
                 return lst;
@@ -123,23 +149,34 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 ? node.Method.GetGenericArguments().Select(i => TypeMappings.ContainsKey(i) ? TypeMappings[i] : i).ToList()//not converting the type it is not in the typeMappings dictionary
                 : null;
 
-            MethodCallExpression resultExp;
-            if (!node.Method.IsStatic)
-            {
-                var instance = ArgumentMapper.Create(this, node.Object).MappedArgumentExpression;
+            ConvertTypesIfNecessary(node.Method.GetParameters(), listOfArgumentsForNewMethod, node.Method);
 
-                resultExp = node.Method.IsGenericMethod
+            return node.Method.IsStatic
+                    ? GetStaticExpression()
+                    : GetInstanceExpression(ArgumentMapper.Create(this, node.Object).MappedArgumentExpression);
+
+            MethodCallExpression GetInstanceExpression(Expression instance)
+                => node.Method.IsGenericMethod
                     ? Expression.Call(instance, node.Method.Name, typeArgsForNewMethod.ToArray(), listOfArgumentsForNewMethod.ToArray())
                     : Expression.Call(instance, node.Method, listOfArgumentsForNewMethod.ToArray());
-            }
-            else
-            {
-                resultExp = node.Method.IsGenericMethod
+
+            MethodCallExpression GetStaticExpression()
+                => node.Method.IsGenericMethod
                     ? Expression.Call(node.Method.DeclaringType, node.Method.Name, typeArgsForNewMethod.ToArray(), listOfArgumentsForNewMethod.ToArray())
                     : Expression.Call(node.Method, listOfArgumentsForNewMethod.ToArray());
-            }
+        }
 
-            return resultExp;
+        void ConvertTypesIfNecessary(ParameterInfo[] parameters, List<Expression> listOfArgumentsForNewMethod, MethodInfo mInfo)
+        {
+            if (mInfo.IsGenericMethod)
+                return;
+
+            for (int i = 0; i < listOfArgumentsForNewMethod.Count; i++)
+            {
+                if (listOfArgumentsForNewMethod[i].Type != parameters[i].ParameterType
+                    && parameters[i].ParameterType.IsAssignableFrom(listOfArgumentsForNewMethod[i].Type))
+                    listOfArgumentsForNewMethod[i] = Expression.Convert(listOfArgumentsForNewMethod[i], parameters[i].ParameterType);
+            }
         }
 
         protected string BuildFullName(List<PropertyMapInfo> propertyMapInfoList)
@@ -180,10 +217,10 @@ namespace AutoMapper.Extensions.ExpressionMapping
             switch (sourceMemberInfo)
             {
                 case PropertyInfo propertyInfo:
-                    propertyMapInfoList.Add(new PropertyMapInfo(null, new List<MemberInfo> {propertyInfo}));
+                    propertyMapInfoList.Add(new PropertyMapInfo(null, new List<MemberInfo> { propertyInfo }));
                     break;
                 case FieldInfo fieldInfo:
-                    propertyMapInfoList.Add(new PropertyMapInfo(null, new List<MemberInfo> {fieldInfo}));
+                    propertyMapInfoList.Add(new PropertyMapInfo(null, new List<MemberInfo> { fieldInfo }));
                     break;
             }
         }
@@ -199,7 +236,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
 
                     if (list.Count == 0)
                     {
-                        AddPropertyMapInfo(typeSource,  next, list);
+                        AddPropertyMapInfo(typeSource, next, list);
                     }
                     else
                     {
@@ -232,15 +269,22 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 {
                     throw new InvalidOperationException(Resource.customResolversNotSupported);
                 }
-                if (propertyMap.CustomExpression != null)
+
+                if (propertyMap.CustomExpression == null && propertyMap.SourceMember == null)
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.srcMemberCannotBeNullFormat, typeSource.Name, typeDestination.Name, sourceFullName));
+
+                CompareSourceAndDestLiterals
+                (
+                    propertyMap.CustomExpression != null ? propertyMap.CustomExpression.ReturnType : propertyMap.SourceMember.GetMemberType(),
+                    propertyMap.CustomExpression != null ? propertyMap.CustomExpression.ToString() : propertyMap.SourceMember.Name,
+                    sourceMemberInfo.GetMemberType()
+                );
+
+                void CompareSourceAndDestLiterals(Type mappedPropertyType, string mappedPropertyDescription, Type sourceMemberType)
                 {
-                    if (propertyMap.CustomExpression.ReturnType.IsValueType() && sourceMemberInfo.GetMemberType() != propertyMap.CustomExpression.ReturnType)
-                        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.expressionMapValueTypeMustMatchFormat, propertyMap.CustomExpression.ReturnType.Name, propertyMap.CustomExpression.ToString(), sourceMemberInfo.GetMemberType().Name, propertyMap.DestinationProperty.Name));
-                }
-                else
-                {
-                    if (propertyMap.SourceMember.GetMemberType().IsValueType() && sourceMemberInfo.GetMemberType() != propertyMap.SourceMember.GetMemberType())
-                        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.expressionMapValueTypeMustMatchFormat, propertyMap.SourceMember.GetMemberType().Name, propertyMap.SourceMember.Name, sourceMemberInfo.GetMemberType().Name, propertyMap.DestinationProperty.Name));
+                    //switch from IsValueType to IsLiteralType because we do not want to throw an exception for all structs
+                    if ((mappedPropertyType.IsLiteralType() || sourceMemberType.IsLiteralType()) && sourceMemberType != mappedPropertyType)
+                        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.expressionMapValueTypeMustMatchFormat, mappedPropertyType.Name, mappedPropertyDescription, sourceMemberType.Name, propertyMap.DestinationProperty.Name));
                 }
 
                 propertyMapInfoList.Add(new PropertyMapInfo(propertyMap.CustomExpression, propertyMap.SourceMembers.ToList()));

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
@@ -1,0 +1,121 @@
+﻿using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using Xunit;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
+{
+    public class XpressionMapperStructsTests
+    {
+        [Fact]
+        public void Can_map_value_types_constants_with_instance_methods()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<GarageModel, Garage>()
+                    .ReverseMap()
+                        .ForMember(d => d.Color, opt => opt.MapFrom(s => s.Truck.Color));
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var mapper = config.CreateMapper();
+
+            List<Garage> source = new List<Garage> {
+                new Garage { Truck = default }
+            };
+
+            //Act
+            var output1 = source.AsQueryable().GetItems<GarageModel, Garage>(mapper, q => q.Truck.Equals(default(TruckModel)));
+            var output2 = source.AsQueryable().Query<GarageModel, Garage, GarageModel, Garage>(mapper, q => q.First());
+            output1.First().Truck.ShouldBe(default);
+            output2.Truck.ShouldBe(default);
+        }
+
+        [Fact]
+        public void Can_convert_return_type()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<GarageModel, Garage>()
+                    .ReverseMap()
+                        .ForMember(d => d.Color, opt => opt.MapFrom(s => s.Truck.Color));
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var mapper = config.CreateMapper();
+
+            List<Garage> source = new List<Garage> {
+                new Garage { Truck = new Truck { Color = "blue", Year = 2000 } }
+            };
+
+            //Act
+            var output1 = source.AsQueryable().GetItems<GarageModel, Garage>(mapper, q => q.Truck.Year == 2000).Select(g => g.Truck);
+            var output2 = source.AsQueryable().Query<GarageModel, Garage, TruckModel, Truck>(mapper, q => q.Select(g => g.Truck).First());
+
+            output1.First().Year.ShouldBe(2000);
+            output2.Year.ShouldBe(2000);
+        }
+    }
+
+    public struct Garage
+    {
+        public Truck Truck { get; set; }
+    }
+
+    public struct GarageModel
+    {
+        public string Color { get; set; }
+        public TruckModel Truck { get; set; }
+    }
+
+    public struct Truck
+    {
+        public string Color { get; set; }
+        public int Year { get; set; }
+    }
+
+    public struct TruckModel
+    {
+        public string Color { get; set; }
+        public int Year { get; set; }
+    }
+
+    static class Extensions
+    {
+        internal static ICollection<TModel> GetItems<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
+        Expression<Func<TModel, bool>> filter = null,
+        Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null)
+        {
+            //Map the expressions
+            Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
+            Func<IQueryable<TData>, IQueryable<TData>> queryableFunc = mapper.MapExpression<Expression<Func<IQueryable<TData>, IQueryable<TData>>>>(queryFunc)?.Compile();
+
+            if (filter != null)
+                query = query.Where(f);
+
+            //Call the store
+            ICollection<TData> list = queryableFunc != null ? queryableFunc(query).ToList() : query.ToList();
+
+            //Map and return the data
+            return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(list).ToList();
+        }
+
+
+        internal static TModelResult Query<TModel, TData, TModelResult, TDataResult>(this IQueryable<TData> query, IMapper mapper,
+            Expression<Func<IQueryable<TModel>, TModelResult>> queryFunc)
+        {
+            //Map the expressions
+            Func<IQueryable<TData>, TDataResult> mappedQueryFunc = mapper.MapExpression<Expression<Func<IQueryable<TData>, TDataResult>>>(queryFunc).Compile();
+
+            //execute the query
+            return mapper.Map<TDataResult, TModelResult>(mappedQueryFunc(query));
+        }
+    }
+}


### PR DESCRIPTION
1. Improves mapping of constants in expressions.
2. Maps expressions where the type changes for instance methods.
3. Fixes #2543 (XpressionMapper does not convert the delegate return type).

The changes are dependent on #2658 (Break out expression mapper) i.e. v.Next so a build failure is expected.