### PR TITLE
Fix to map members of the generic type definition during expression mapping

### DIFF
--- a/AutoMapper.Extensions.ExpressionMapping.sln
+++ b/AutoMapper.Extensions.ExpressionMapping.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoMapper.Extensions.ExpressionMapping", "src\AutoMapper.Extensions.ExpressionMapping\AutoMapper.Extensions.ExpressionMapping.csproj", "{24DF305C-EE59-460A-BA97-4B7CD5505434}"
 EndProject
@@ -17,8 +17,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoMapper", "..\AutoMapper\src\AutoMapper\AutoMapper.csproj", "{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,18 +52,6 @@ Global
 		{31D058FF-FD83-4DB3-9C32-1D3599687A8E}.Release|x64.Build.0 = Release|Any CPU
 		{31D058FF-FD83-4DB3-9C32-1D3599687A8E}.Release|x86.ActiveCfg = Release|Any CPU
 		{31D058FF-FD83-4DB3-9C32-1D3599687A8E}.Release|x86.Build.0 = Release|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Debug|x64.Build.0 = Debug|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Debug|x86.Build.0 = Debug|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Release|x64.ActiveCfg = Release|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Release|x64.Build.0 = Release|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Release|x86.ActiveCfg = Release|Any CPU
-		{DB328395-6418-42A7-A5C2-FFFEF9BDBE02}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AutoMapper.Extensions.ExpressionMapping/AutoMapper.Extensions.ExpressionMapping.csproj
+++ b/src/AutoMapper.Extensions.ExpressionMapping/AutoMapper.Extensions.ExpressionMapping.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="7.0.0" />
+    <PackageReference Include="AutoMapper" Version="7.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Extensions.ExpressionMapping/AutoMapper.Extensions.ExpressionMapping.csproj
+++ b/src/AutoMapper.Extensions.ExpressionMapping/AutoMapper.Extensions.ExpressionMapping.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\AutoMapper\src\AutoMapper\AutoMapper.csproj" />
+    <PackageReference Include="AutoMapper" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Extensions.ExpressionMapping/ExpressionExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/ExpressionExtensions.cs
@@ -7,6 +7,7 @@ using AutoMapper.Internal;
 
 namespace AutoMapper
 {
+    using AutoMapper.Extensions.ExpressionMapping;
     using static Expression;
 
     internal static class ExpressionExtensions
@@ -55,5 +56,24 @@ namespace AutoMapper
 
         public static Expression IfNullElse(this Expression expression, Expression then, Expression @else = null)
             => ExpressionFactory.IfNullElse(expression, then, @else);
+    }
+
+    internal static class ExpressionHelpers
+    {
+        public static MemberExpression MemberAccesses(string members, Expression obj) =>
+            (MemberExpression)GetMemberPath(obj.Type, members).MemberAccesses(obj);
+
+        private static IEnumerable<MemberInfo> GetMemberPath(Type type, string fullMemberName)
+        {
+            MemberInfo property = null;
+            foreach (var memberName in fullMemberName.Split('.'))
+            {
+                var currentType = GetCurrentType(property, type);
+                yield return property = currentType.GetFieldOrProperty(memberName);
+            }
+        }
+
+        private static Type GetCurrentType(MemberInfo member, Type type)
+            => member?.GetMemberType() ?? type;
     }
 }

--- a/src/AutoMapper.Extensions.ExpressionMapping/FindMemberExpressionsVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/FindMemberExpressionsVisitor.cs
@@ -37,7 +37,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                     return result;
                 });
 
-                return ExpressionFactory.MemberAccesses(member, _newParameter);
+                return ExpressionHelpers.MemberAccesses(member, _newParameter);
             }
         }
 

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
@@ -96,7 +96,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 return v.Result;
             }
             fullName = BuildFullName(propertyMapInfoList);
-            var me = ExpressionFactory.MemberAccesses(fullName, InfoDictionary[parameterExpression].NewParameter);
+            var me = ExpressionHelpers.MemberAccesses(fullName, InfoDictionary[parameterExpression].NewParameter);
             if (me.Expression.NodeType == ExpressionType.MemberAccess && (me.Type == typeof(string) || me.Type.GetTypeInfo().IsValueType || (me.Type.GetTypeInfo().IsGenericType
                                                                                                                                              && me.Type.GetGenericTypeDefinition() == typeof(Nullable<>)
                                                                                                                                              && Nullable.GetUnderlyingType(me.Type).GetTypeInfo().IsValueType)))

--- a/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
@@ -40,7 +40,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                             ? sourcePath
                             : string.Concat(ParentFullName, ".", sourcePath);
 
-            var me = ExpressionFactory.MemberAccesses(fullName, NewParameter);
+            var me = ExpressionHelpers.MemberAccesses(fullName, NewParameter);
 
             return me;
         }

--- a/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
@@ -29,11 +29,6 @@ namespace AutoMapper
         public static MethodInfo GetRemoveMethod(this EventInfo eventInfo) => eventInfo.RemoveMethod;
 #endif
 
-        public static Type CreateType(this TypeBuilder type)
-        {
-            return type.CreateTypeInfo().AsType();
-        }
-
         public static IEnumerable<MemberInfo> GetDeclaredMembers(this Type type) => type.GetTypeInfo().DeclaredMembers;
 
         public static IEnumerable<Type> GetTypeInheritance(this Type type)

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Shouldly;
 using Xunit;
+using AutoMapper;
 
 namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
 {
@@ -409,6 +410,32 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             List<IGrouping<int, User>> users = expMapped.Compile().Invoke(Users).ToList();
 
             Assert.True(users[0].Count() == 2);
+        }
+
+        [Fact]
+        public void Map_orderBy_thenBy_GroupBy_Select_expression()
+        {
+            //Arrange
+            Expression<Func<IQueryable<UserModel>, IQueryable<object>>> grouped = q => q.OrderBy(s => s.Id).ThenBy(s => s.FullName).GroupBy(s => s.AgeInYears).Select(grp => new { Id = grp.Key, Count = grp.Count() });
+
+            //Act
+            Expression<Func<IQueryable<User>, IQueryable<object>>> expMapped = mapper.MapExpression<Expression<Func<IQueryable<User>, IQueryable<object>>>>(grouped);
+            List<dynamic> users = expMapped.Compile().Invoke(Users).ToList();
+
+            Assert.True(users[0].Count == 2);
+        }
+
+        [Fact]
+        public void Map_orderBy_thenBy_To_Dictionary_Select_expression()
+        {
+            //Arrange
+            Expression<Func<IQueryable<UserModel>, IEnumerable<object>>> grouped = q => q.OrderBy(s => s.Id).ThenBy(s => s.FullName).ToDictionary(kvp => kvp.Id).Select(grp => new { Id = grp.Key, Name = grp.Value.FullName });
+
+            //Act
+            Expression<Func<IQueryable<User>, IEnumerable<object>>> expMapped = mapper.MapExpression<Expression<Func<IQueryable<User>, IEnumerable<object>>>>(grouped);
+            List<dynamic> users = expMapped.Compile().Invoke(Users).ToList();
+
+            Assert.True(users[0].Id == 11);
         }
 
         [Fact]


### PR DESCRIPTION
The logic for mapping expressions between members of a generic type definition is different because type maps do not exist.

e.g. mapping an expression with `IGrouping<int, User>.Key` to `IGrouping<int, UserModel>.Key` or `IGrouping<int, User>.Value` to `IGrouping<int, UserModel>.Value`  needed additional handling.