### PR TITLE
Allow mapping of generic methods in expressions irrespective of the parameter

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
@@ -69,12 +69,14 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 return (TDestDelegate)Lambda
                 (
                     typeDestFunc,
-                    ExpressionFactory.ToType(remappedBody, typeDestFunc.GetGenericArguments().Last()),
+                    typeDestFunc.IsFuncType() ? ExpressionFactory.ToType(remappedBody, typeDestFunc.GetGenericArguments().Last()) : remappedBody,
                     expression.GetDestinationParameterExpressions(visitor.InfoDictionary, typeMappings)
                 );
             }
         }
 
+        private static bool IsFuncType(this Type type)
+            => type.FullName.StartsWith("System.Func");
 
         /// <summary>
         /// Maps an expression given a dictionary of types where the source type is the key and the destination type is the value.

--- a/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
@@ -146,15 +146,11 @@ namespace AutoMapper.Extensions.ExpressionMapping
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             var parameterExpression = node.GetParameterExpression();
-            if (parameterExpression == null)
-                return base.VisitMethodCall(node);
-
-            InfoDictionary.Add(parameterExpression, TypeMappings);
+            if (parameterExpression != null)
+                InfoDictionary.Add(parameterExpression, TypeMappings);
 
             var listOfArgumentsForNewMethod = node.Arguments.Aggregate(new List<Expression>(), (lst, next) =>
             {
-                //var mappedNext = ArgumentMapper.Create(this, next).MappedArgumentExpression;
-                //Using VisitUnary and VisitLambda instead of ArgumentMappers
                 var mappedNext = this.Visit(next);
                 TypeMappings.AddTypeMapping(ConfigurationProvider, next.Type, mappedNext.Type);
 
@@ -168,11 +164,6 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 : null;
 
             ConvertTypesIfNecessary(node.Method.GetParameters(), listOfArgumentsForNewMethod, node.Method);
-
-            /*Using VisitUnary and VisitLambda instead of ArgumentMappers
-             * return node.Method.IsStatic
-                    ? GetStaticExpression()
-                    : GetInstanceExpression(ArgumentMapper.Create(this, node.Object).MappedArgumentExpression);*/
 
             return node.Method.IsStatic
                     ? GetStaticExpression()

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -601,6 +601,40 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             //Assert
             Assert.NotNull(dest);
         }
+
+        [Fact]
+        public void Can_map_expressions_with_no_parameters()
+        {
+            //Arrange
+            Expression<Func<OptionS>> exp = () => Activator.CreateInstance<OptionS>();
+
+            //Act
+            Expression<Func<OptionT>> expmapped = mapper.Map<Expression<Func<OptionS>>, Expression<Func<OptionT>>>(exp);
+
+            //Assert
+            Assert.True(expmapped.Type == typeof(Func<OptionT>));
+        }
+
+
+        [Fact]
+        public void Can_map_expressions_with_action_independent_of_expression_param()
+        {
+            //Arrange
+            Expression<Action<OptionS>> exp = (s) => CallSomeAction<OptionS>(Activator.CreateInstance<OptionS>());
+
+            //Act
+            Expression<Action<OptionT>> expmapped = mapper.MapExpression<Expression<Action<OptionS>>, Expression<Action<OptionT>>>(exp);
+
+            //Assert
+            expmapped.Compile()(Activator.CreateInstance<OptionT>());
+            Assert.True(this.val.GetType() == typeof(OptionT));
+        }
+
+        object val;
+        void CallSomeAction<T>(T val)
+        {
+            this.val = val;
+        }
         #endregion Tests
 
         private static void SetupAutoMapper()
@@ -696,6 +730,16 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         }
 
         private static IQueryable<User> Users { get; set; }
+    }
+
+    public class OptionS
+    {
+        public static OptionS GetNew() => new OptionS();
+    }
+
+    public class OptionT
+    {
+        public static OptionT GetNew() => new OptionT();
     }
 
     public class Account
@@ -1065,6 +1109,8 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             CreateMap<OrderEntity, OrderModel>()
                     .ForMember(x => x.Items, opt => opt.MapFrom(x => x.OrderData.Items));
             CreateMap<ItemEntity, ItemModel>();
+
+            CreateMap<OptionT, OptionS>();
 
             CreateMissingTypeMaps = true;
         }


### PR DESCRIPTION
Partial fix for issue #12 

Now it's possible to map the following:
```c#
Expression<Func<OptionS>> exp = () => Activator.CreateInstance<OptionS>();
Expression<Func<OptionT>> expmapped = mapper.Map<Expression<Func<OptionS>>, Expression<Func<OptionT>>>(exp);
```