### PR TITLE
Separate storing underlying types in delegates from property map underlying types.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.5-preview01</VersionPrefix>
+    <VersionPrefix>1.0.5-preview02</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
@@ -256,7 +256,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
             if (typeMappings == null)
                 throw new ArgumentException(Resource.typeMappingsDictionaryIsNull);
 
-            typeMappings.DoAddTypeMappings
+            typeMappings.DoAddTypeMappingsFromDelegates
             (
                 configurationProvider,
                 sourceType.GetGenericArguments().ToList(),
@@ -266,10 +266,22 @@ namespace AutoMapper.Extensions.ExpressionMapping
             return typeMappings;
         }
 
-        private static void DoAddTypeMappings(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, List<Type> sourceArguments, List<Type> destArguments)
+        private static void DoAddTypeMappingsFromDelegates(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, List<Type> sourceArguments, List<Type> destArguments)
         {
             if (sourceArguments.Count != destArguments.Count)
                 throw new ArgumentException(Resource.invalidArgumentCount);
+
+            for (int i = 0; i < sourceArguments.Count; i++)
+            {
+                if (!typeMappings.ContainsKey(sourceArguments[i]) && sourceArguments[i] != destArguments[i])
+                    typeMappings.AddTypeMapping(configurationProvider, sourceArguments[i], destArguments[i]);
+            }
+        }
+
+        private static void DoAddTypeMappings(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, List<Type> sourceArguments, List<Type> destArguments)
+        {
+            if (sourceArguments.Count != destArguments.Count)
+                return;
 
             for (int i = 0; i < sourceArguments.Count; i++)
             {


### PR DESCRIPTION
This fix stops unexpected error "Source and destination must have the same number of arguments.". 

When the sources of underlying types are the expressions being mapped we expect the number of arguments to match.  For property maps the number of generic arguments may not be equal.
