### PR TITLE
Release 1.0.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.5-preview02</VersionPrefix>
+    <VersionPrefix>1.0.5</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -635,6 +635,19 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         {
             this.val = val;
         }
+
+        [Fact]
+        public void Can_map_expression_when_mapped_properties_have_a_different_generic_argument_counts()
+        {
+            //Arrange
+            Expression<Func<ListParent, bool>> src = x => x.List.Count == 0;
+
+            //Act
+            Expression<Func<ListParentExtension, bool>> dest = mapper.Map<Expression<Func<ListParentExtension, bool>>>(src);
+
+            //Assert
+            Assert.NotNull(dest);
+        }
         #endregion Tests
 
         private static void SetupAutoMapper()
@@ -1018,6 +1031,20 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         public string Name { get; set; }
     }
 
+    class ListParentExtension 
+    {
+        public ListExtension List { get; set; }
+    }
+
+    class ListParent : List<string>
+    {
+        public List<string> List { get; set; }
+    }
+
+    class ListExtension : List<string>
+    {
+    }
+
     public class OrganizationProfile : Profile
     {
         public OrganizationProfile()
@@ -1111,6 +1138,13 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             CreateMap<ItemEntity, ItemModel>();
 
             CreateMap<OptionT, OptionS>();
+
+            CreateMap<ListParentExtension, ListParent>()
+                .ReverseMap();
+            CreateMap<ListExtension, List<string>>()
+                .ForMember(d => d.Count, opt => opt.MapFrom(s => s.Count))
+                .ReverseMap()
+                .ForMember(d => d.Count, opt => opt.MapFrom(s => s.Count));
 
             CreateMissingTypeMaps = true;
         }


### PR DESCRIPTION
Fixes:
Source and destination must have the same number of arguments. (Issue #17)
Custom type with op_equality override failed to convert (Issue #15)