### PR TITLE
Add support for Type Binary Expressions, and member accesses off of them

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>3.0.2-preview02</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ AutoMapper extentions for mapping expressions (OData)
 To use, configure using the configuration helper method:
 
 ```c#
-Mapper.Initialize(cfg => {
+var mapper = new Mapper(new MapperConfiguration(cfg => {
     cfg.AddExpressionMapping();
 	// Rest of your configuration
-});
+}));
 
 // or if using the MS Ext DI:
 

--- a/src/AutoMapper.Extensions.ExpressionMapping/AutoMapper.Extensions.ExpressionMapping.csproj
+++ b/src/AutoMapper.Extensions.ExpressionMapping/AutoMapper.Extensions.ExpressionMapping.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.1.0" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
@@ -63,7 +63,7 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
                     return string.Empty;
             }
         }
-        
+
         /// <summary>
         /// Returns the ParameterExpression for the LINQ parameter.
         /// </summary>
@@ -73,8 +73,8 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
         {
             if (expression == null)
                 return null;
-            
-            switch(expression)
+
+            switch (expression)
             {
                 case ParameterExpression pe:
                     return pe;

--- a/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
@@ -53,17 +53,15 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
             //the node represents parameter of the expression
             switch (expression.NodeType)
             {
-                case ExpressionType.Parameter:
-                    return string.Empty;
                 case ExpressionType.MemberAccess:
                     var memberExpression = (MemberExpression)expression;
                     var parentFullName = memberExpression.Expression.GetPropertyFullName();
                     return string.IsNullOrEmpty(parentFullName)
                         ? memberExpression.Member.Name
                         : string.Concat(memberExpression.Expression.GetPropertyFullName(), period, memberExpression.Member.Name);
+                default:
+                    return string.Empty;
             }
-
-            throw new InvalidOperationException(Resource.invalidExpErr);
         }
 
         private static MemberExpression GetMemberExpression(LambdaExpression expr)
@@ -133,6 +131,22 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns the first ancestor node that is not a MemberExpression.
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        public static Expression GetBaseOfMemberExpression(this MemberExpression expression)
+        {
+            switch(expression.Expression.NodeType)
+            {
+                case ExpressionType.MemberAccess:
+                    return GetBaseOfMemberExpression((MemberExpression)expression.Expression);
+                default:
+                    return expression.Expression;
+            }
         }
 
         /// <summary>

--- a/src/AutoMapper.Extensions.ExpressionMapping/FindMemberExpressionsVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/FindMemberExpressionsVisitor.cs
@@ -10,9 +10,9 @@ namespace AutoMapper.Extensions.ExpressionMapping
 {
     internal class FindMemberExpressionsVisitor : ExpressionVisitor
     {
-        internal FindMemberExpressionsVisitor(ParameterExpression newParameter) => _newParameter = newParameter;
+        internal FindMemberExpressionsVisitor(Expression newParentExpression) => _newParentExpression = newParentExpression;
 
-        private readonly ParameterExpression _newParameter;
+        private readonly Expression _newParentExpression;
         private readonly List<MemberExpression> _memberExpressions = new List<MemberExpression>();
 
         public MemberExpression Result
@@ -31,13 +31,13 @@ namespace AutoMapper.Extensions.ExpressionMapping
                         result = next;
                     else throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                         Resource.includeExpressionTooComplex,
-                        string.Concat(_newParameter.Type.Name, period, result),
-                        string.Concat(_newParameter.Type.Name, period, next)));
+                        string.Concat(_newParentExpression.Type.Name, period, result),
+                        string.Concat(_newParentExpression.Type.Name, period, next)));
 
                     return result;
                 });
 
-                return ExpressionHelpers.MemberAccesses(member, _newParameter);
+                return ExpressionHelpers.MemberAccesses(member, _newParentExpression);
             }
         }
 
@@ -45,7 +45,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
         {
             var parameterExpression = node.GetParameterExpression();
             var sType = parameterExpression?.Type;
-            if (sType != null && _newParameter.Type == sType && node.IsMemberExpression())
+            if (sType != null && _newParentExpression.Type == sType && node.IsMemberExpression())
             {
                 if (node.Expression.NodeType == ExpressionType.MemberAccess && node.Type.IsLiteralType())
                     _memberExpressions.Add((MemberExpression)node.Expression);

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
@@ -16,52 +16,21 @@ namespace AutoMapper.Extensions.ExpressionMapping
         {
         }
 
-        protected override Expression VisitUnary(UnaryExpression node)
-        {
-            switch (node.NodeType)
-            {
-                case ExpressionType.Convert:
-                case ExpressionType.ConvertChecked:
-
-                    var me = node.Operand as MemberExpression;
-                    var parameterExpression = node.GetParameterExpression();
-                    var sType = parameterExpression?.Type;
-                    if (me != null && (sType != null && me.Expression.NodeType == ExpressionType.MemberAccess && me.Type.IsLiteralType()))
-                    {
-                        //just pass me and let the FindMemberExpressionsVisitor handle removing of the value type
-                        //me.Expression will not match the PathMap name.
-                        return Visit(me);
-                    }
-                    else
-                    {
-                        return base.VisitUnary(node);
-                    }
-                default:
-                    return base.VisitUnary(node);
-            }
-        }
-
         protected override Expression VisitMember(MemberExpression node)
         {
-            string sourcePath;
-
             var parameterExpression = node.GetParameterExpression();
             if (parameterExpression == null)
                 return base.VisitMember(node);
 
             InfoDictionary.Add(parameterExpression, TypeMappings);
-            var sType = parameterExpression.Type;
-            if (sType != null && InfoDictionary.ContainsKey(parameterExpression) && node.IsMemberExpression())
-            {
-                sourcePath = node.GetPropertyFullName();
-            }
-            else
-            {
-                return base.VisitMember(node);
-            }
+            string sourcePath = node.GetPropertyFullName();
+            Expression baseParentExpr = node.GetBaseOfMemberExpression();
+            Expression visitedParentExpr = this.Visit(baseParentExpr);
+            Type sType = baseParentExpr.Type;
+            Type dType = visitedParentExpr.Type;
 
             var propertyMapInfoList = new List<PropertyMapInfo>();
-            FindDestinationFullName(sType, InfoDictionary[parameterExpression].DestType, sourcePath, propertyMapInfoList);
+            FindDestinationFullName(sType, dType, sourcePath, propertyMapInfoList);
             string fullName;
 
             if (propertyMapInfoList.Any(x => x.CustomExpression != null))//CustomExpression takes precedence over DestinationPropertyInfo
@@ -84,22 +53,25 @@ namespace AutoMapper.Extensions.ExpressionMapping
 
                 fullName = BuildFullName(beforeCustExpression);
 
-                var visitor = new PrependParentNameVisitor(last.CustomExpression.Parameters[0].Type/*Parent type of current property*/, fullName, InfoDictionary[parameterExpression].NewParameter);
+                var visitor = new PrependParentNameVisitor
+                (
+                    last.CustomExpression.Parameters[0].Type/*Parent type of current property*/,
+                    fullName,
+                    visitedParentExpr
+                );
 
                 var ex = propertyMapInfoList[propertyMapInfoList.Count - 1] != last
                     ? visitor.Visit(last.CustomExpression.Body.MemberAccesses(afterCustExpression))
                     : visitor.Visit(last.CustomExpression.Body);
 
-                var v = new FindMemberExpressionsVisitor(InfoDictionary[parameterExpression].NewParameter);
+                var v = new FindMemberExpressionsVisitor(visitedParentExpr);
                 v.Visit(ex);
 
                 return v.Result;
             }
             fullName = BuildFullName(propertyMapInfoList);
             var me = ExpressionHelpers.MemberAccesses(fullName, InfoDictionary[parameterExpression].NewParameter);
-            if (me.Expression.NodeType == ExpressionType.MemberAccess && (me.Type == typeof(string) || me.Type.GetTypeInfo().IsValueType || (me.Type.GetTypeInfo().IsGenericType
-                                                                                                                                             && me.Type.GetGenericTypeDefinition() == typeof(Nullable<>)
-                                                                                                                                             && Nullable.GetUnderlyingType(me.Type).GetTypeInfo().IsValueType)))
+            if (me.Expression.NodeType == ExpressionType.MemberAccess && me.Type.IsLiteralType())
             {
                 return me.Expression;
             }

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
@@ -245,6 +245,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 {
                     typeMappings.AddUnderlyingTypes(configurationProvider, sourceType, destType);
                     typeMappings.FindChildPropertyTypeMaps(configurationProvider, sourceType, destType);
+                    typeMappings.AddIncludedTypeMaps(configurationProvider, sourceType, destType);
                 }
             }
 
@@ -300,6 +301,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 return;
 
             FindMaps(typeMap.PropertyMaps.ToList());
+
             void FindMaps(List<PropertyMap> maps)
             {
                 foreach (PropertyMap pm in maps)
@@ -312,6 +314,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                         source.GetFieldOrProperty(pm.DestinationMember.Name).GetMemberType(),
                         pm.SourceMember.GetMemberType()
                     );
+
                     void AddChildMappings(Type sourcePropertyType, Type destPropertyType)
                     {
                         if (sourcePropertyType.IsLiteralType() || destPropertyType.IsLiteralType())
@@ -320,6 +323,24 @@ namespace AutoMapper.Extensions.ExpressionMapping
                         typeMappings.AddTypeMapping(ConfigurationProvider, sourcePropertyType, destPropertyType);
                     }
                 }
+            }
+        }
+
+        private static void AddIncludedTypeMaps(this Dictionary<Type, Type> typeMappings, IConfigurationProvider configurationProvider, Type source, Type dest)
+        {
+            var typeMap = configurationProvider.ResolveTypeMap(source, dest);
+
+            if (typeMap == null)
+                return;
+
+            foreach(var includedBase in typeMap.IncludedBaseTypes)
+            {
+                typeMappings.AddTypeMapping(configurationProvider, includedBase.SourceType, includedBase.DestinationType);
+            }
+
+            foreach(var includedDerived in typeMap.IncludedDerivedTypes)
+            {
+                typeMappings.AddTypeMapping(configurationProvider, includedDerived.SourceType, includedDerived.DestinationType);
             }
         }
     }

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapperExtensions.cs
@@ -36,8 +36,8 @@ namespace AutoMapper.Extensions.ExpressionMapping
         {
             return MapExpression<TDestDelegate>
             (
-                mapper ?? Mapper.Instance,
-                mapper == null ? Mapper.Configuration : mapper.ConfigurationProvider,
+                mapper,
+                mapper.ConfigurationProvider,
                 expression,
                 expression.GetType().GetGenericArguments()[0],
                 typeof(TDestDelegate).GetGenericArguments()[0],
@@ -301,7 +301,6 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 return;
 
             FindMaps(typeMap.PropertyMaps.ToList());
-
             void FindMaps(List<PropertyMap> maps)
             {
                 foreach (PropertyMap pm in maps)
@@ -314,7 +313,6 @@ namespace AutoMapper.Extensions.ExpressionMapping
                         source.GetFieldOrProperty(pm.DestinationMember.Name).GetMemberType(),
                         pm.SourceMember.GetMemberType()
                     );
-
                     void AddChildMappings(Type sourcePropertyType, Type destPropertyType)
                     {
                         if (sourcePropertyType.IsLiteralType() || destPropertyType.IsLiteralType())
@@ -333,12 +331,12 @@ namespace AutoMapper.Extensions.ExpressionMapping
             if (typeMap == null)
                 return;
 
-            foreach(var includedBase in typeMap.IncludedBaseTypes)
+            foreach (var includedBase in typeMap.IncludedBaseTypes)
             {
                 typeMappings.AddTypeMapping(configurationProvider, includedBase.SourceType, includedBase.DestinationType);
             }
 
-            foreach(var includedDerived in typeMap.IncludedDerivedTypes)
+            foreach (var includedDerived in typeMap.IncludedDerivedTypes)
             {
                 typeMappings.AddTypeMapping(configurationProvider, includedDerived.SourceType, includedDerived.DestinationType);
             }

--- a/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
@@ -7,16 +7,16 @@ namespace AutoMapper.Extensions.ExpressionMapping
 {
     internal class PrependParentNameVisitor : ExpressionVisitor
     {
-        public PrependParentNameVisitor(Type currentParameterType, string parentFullName, Expression baseExpression)
+        public PrependParentNameVisitor(Type currentParameterType, string parentFullName, Expression newParameter)
         {
             CurrentParameterType = currentParameterType;
             ParentFullName = parentFullName;
-            this.baseExpression = baseExpression;
+            NewParameter = newParameter;
         }
 
         public Type CurrentParameterType { get; }
         public string ParentFullName { get; }
-        public Expression baseExpression { get; } 
+        public Expression NewParameter { get; }
 
         protected override Expression VisitMember(MemberExpression node)
         {
@@ -40,7 +40,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                             ? sourcePath
                             : string.Concat(ParentFullName, ".", sourcePath);
 
-            var me = ExpressionHelpers.MemberAccesses(fullName, baseExpression);
+            var me = ExpressionHelpers.MemberAccesses(fullName, NewParameter);
 
             return me;
         }

--- a/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
@@ -7,16 +7,16 @@ namespace AutoMapper.Extensions.ExpressionMapping
 {
     internal class PrependParentNameVisitor : ExpressionVisitor
     {
-        public PrependParentNameVisitor(Type currentParameterType, string parentFullName, ParameterExpression newParameter)
+        public PrependParentNameVisitor(Type currentParameterType, string parentFullName, Expression baseExpression)
         {
             CurrentParameterType = currentParameterType;
             ParentFullName = parentFullName;
-            NewParameter = newParameter;
+            this.baseExpression = baseExpression;
         }
 
         public Type CurrentParameterType { get; }
         public string ParentFullName { get; }
-        public ParameterExpression NewParameter { get; } 
+        public Expression baseExpression { get; } 
 
         protected override Expression VisitMember(MemberExpression node)
         {
@@ -40,7 +40,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
                             ? sourcePath
                             : string.Concat(ParentFullName, ".", sourcePath);
 
-            var me = ExpressionHelpers.MemberAccesses(fullName, NewParameter);
+            var me = ExpressionHelpers.MemberAccesses(fullName, baseExpression);
 
             return me;
         }

--- a/src/AutoMapper.Extensions.ExpressionMapping/QueryableExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/QueryableExtensions.cs
@@ -5,9 +5,6 @@ namespace AutoMapper.Extensions.ExpressionMapping
 {
     public static class QueryableExtensions
     {
-        public static IQueryDataSourceInjection<TSource> UseAsDataSource<TSource>(this IQueryable<TSource> dataSource)
-            => dataSource.UseAsDataSource(Mapper.Configuration?.CreateMapper());
-
         public static IQueryDataSourceInjection<TSource> UseAsDataSource<TSource>(this IQueryable<TSource> dataSource, IConfigurationProvider config)
             => dataSource.UseAsDataSource(config.CreateMapper());
 

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionConversion.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionConversion.cs
@@ -28,6 +28,52 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             public int ChildValue { get; set; }
         }
 
+        public enum SourceEnum
+        {
+            Foo,
+            Bar
+        }
+
+        public enum DestEnum
+        {
+            Foo,
+            Bar
+        }
+
+        public class SourceWithEnum : Source
+        {
+            public SourceEnum Enum { get; set; }
+        }
+
+        public class DestWithEnum : Dest
+        {
+            public DestEnum Enum { get; set; }
+        }
+
+        [Fact]
+        public void Can_map_unary_expression_converting_enum_to_int()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.AddExpressionMapping();
+                cfg.CreateMap<SourceEnum, DestEnum>();
+                cfg.CreateMap<DestWithEnum, SourceWithEnum>();
+            });
+
+            Expression<Func<SourceWithEnum, bool>> expr = s => s.Enum == SourceEnum.Bar;
+
+            var mapped = config.CreateMapper().MapExpression<Expression<Func<SourceWithEnum, bool>>, Expression<Func<DestWithEnum, bool>>>(expr);
+
+            var items = new[]
+           {
+                new DestWithEnum {Enum = DestEnum.Foo},
+                new DestWithEnum {Enum = DestEnum.Bar},
+                new DestWithEnum {Enum = DestEnum.Bar}
+            };
+
+            var items2 = items.AsQueryable().Select(mapped).ToList();
+        }
+
         [Fact]
         public void Can_map_single_properties()
         {

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMapping.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMapping.cs
@@ -111,7 +111,6 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
             cfg.AddExpressionMapping();
-            cfg.CreateMissingTypeMaps = false;
             cfg.CreateMap<GrandParent, GrandParentDTO>().ReverseMap();
             cfg.CreateMap<Parent, ParentDTO>().ReverseMap();
             cfg.CreateMap<Child, ChildDTO>()

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingPropertyFromDerviedType.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingPropertyFromDerviedType.cs
@@ -1,11 +1,9 @@
 ﻿using Shouldly;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace AutoMapper.Extensions.ExpressionMapping.UnitTests

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingPropertyFromDerviedType.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingPropertyFromDerviedType.cs
@@ -1,0 +1,80 @@
+﻿using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
+{
+    public class ExpressionMappingPropertyFromDerviedType : AutoMapperSpecBase
+    {
+        private List<BaseEntity> _source;
+        private IQueryable<BaseEntity> entityQuery;
+
+        public class BaseDTO
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class BaseEntity
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class DTO : BaseDTO
+        {
+            public string Name { get; set; }
+        }
+
+        public class Entity : BaseEntity
+        {
+            public string Name { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration
+        {
+            get
+            {
+                var config = new MapperConfiguration(cfg =>
+                {
+                    cfg.AddExpressionMapping();
+
+                    cfg.CreateMap<BaseEntity, BaseDTO>();
+                    cfg.CreateMap<BaseDTO, BaseEntity>();
+
+                    cfg.CreateMap<Entity, DTO>()
+                        .IncludeBase<BaseEntity, BaseDTO>();
+                    cfg.CreateMap<DTO, Entity>()
+                        .IncludeBase<BaseDTO, BaseEntity>();
+                });
+                return config;
+            }
+        }
+
+        protected override void Because_of()
+        {
+            //Arrange
+            _source = new List<BaseEntity> {
+                new Entity { Id = Guid.NewGuid(), Name = "Sofia" },
+                new Entity { Id = Guid.NewGuid(), Name = "Rafael" },
+                new BaseEntity { Id = Guid.NewGuid() }
+            };
+
+            // Act
+            Expression<Func<BaseDTO, bool>> dtoQueryExpression = r => (r is DTO ? ((DTO)r).Name : "") == "Sofia";
+            var entityQueryExpression = Mapper.Map<Expression<Func<BaseEntity, bool>>>(dtoQueryExpression);
+            entityQuery = _source.AsQueryable().Where(entityQueryExpression);
+        }
+
+        [Fact]
+        public void Should_support_propertypath_expressions_with_properties_from_assignable_types()
+        {
+            // Assert
+            entityQuery.ToList().Count().ShouldBe(1);
+        }
+    }
+}

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingPropertyFromDerviedType.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingPropertyFromDerviedType.cs
@@ -10,10 +10,9 @@ using Xunit;
 
 namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
 {
-    public class ExpressionMappingPropertyFromDerviedType : AutoMapperSpecBase
+    public class ExpressionMappingPropertyFromDerviedType : NonValidatingSpecBase
     {
         private List<BaseEntity> _source;
-        private IQueryable<BaseEntity> entityQuery;
 
         public class BaseDTO
         {
@@ -28,53 +27,75 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         public class DTO : BaseDTO
         {
             public string Name { get; set; }
+            public string Description { get; set; }
         }
 
         public class Entity : BaseEntity
         {
             public string Name { get; set; }
+            public string Desc { get; set; }
         }
 
-        protected override MapperConfiguration Configuration
-        {
-            get
-            {
-                var config = new MapperConfiguration(cfg =>
+        protected override MapperConfiguration Configuration =>
+            new MapperConfiguration(cfg =>
                 {
                     cfg.AddExpressionMapping();
 
-                    cfg.CreateMap<BaseEntity, BaseDTO>();
-                    cfg.CreateMap<BaseDTO, BaseEntity>();
+                    cfg.CreateMap<BaseEntity, BaseDTO>()
+                        .Include<Entity, DTO>()
+                        .ReverseMap();
 
                     cfg.CreateMap<Entity, DTO>()
-                        .IncludeBase<BaseEntity, BaseDTO>();
-                    cfg.CreateMap<DTO, Entity>()
-                        .IncludeBase<BaseDTO, BaseEntity>();
+                        .IncludeBase<BaseEntity, BaseDTO>()
+                        .ForMember(dto => dto.Description, opt => opt.MapFrom(entity => entity.Desc))
+                        .ReverseMap();
                 });
-                return config;
-            }
-        }
 
         protected override void Because_of()
         {
             //Arrange
             _source = new List<BaseEntity> {
-                new Entity { Id = Guid.NewGuid(), Name = "Sofia" },
-                new Entity { Id = Guid.NewGuid(), Name = "Rafael" },
+                new Entity { Id = Guid.NewGuid(), Name = "Sofia", Desc = "Rafael's Spouse" },
+                new Entity { Id = Guid.NewGuid(), Name = "Rafael", Desc = "Sofia's Spouse" },
                 new BaseEntity { Id = Guid.NewGuid() }
             };
 
-            // Act
-            Expression<Func<BaseDTO, bool>> dtoQueryExpression = r => (r is DTO ? ((DTO)r).Name : "") == "Sofia";
-            var entityQueryExpression = Mapper.Map<Expression<Func<BaseEntity, bool>>>(dtoQueryExpression);
-            entityQuery = _source.AsQueryable().Where(entityQueryExpression);
+            var typeMap = new Dictionary<Type, Type>().AddTypeMapping<BaseDTO, BaseEntity>(this.ConfigProvider);
+            var expressionVisitor = new XpressionMapperVisitor(this.Mapper, this.ConfigProvider, typeMap);
         }
 
         [Fact]
-        public void Should_support_propertypath_expressions_with_properties_from_assignable_types()
+        public void Should_support_propertypath_expressions_with_properties_from_derived_types()
         {
+            var parameterContainer = new
+            {
+                P1 = "Sofia"
+            };
+
+            Expression<Func<BaseDTO, bool>> filter = r => (r as DTO == null ? null : (r as DTO).Name) == parameterContainer.P1;
+            var mappedFilter = this.Mapper.MapExpression<Expression<Func<BaseEntity, bool>>>(filter);
+
             // Assert
-            entityQuery.ToList().Count().ShouldBe(1);
+            _source
+                .AsQueryable()
+                .Where(mappedFilter)
+                .Count()
+                .ShouldBe(1);
+        }
+
+
+        [Fact]
+        public void Should_support_custom_expressions_with_properties_from_derived_types()
+        {
+            Expression<Func<BaseDTO, bool>> filter = r => (r is DTO ? ((DTO)r).Description : "").Contains("Sofia");
+            var mappedFilter = this.Mapper.MapExpression<Expression<Func<BaseEntity, bool>>>(filter);
+
+            // Assert
+            _source
+                .AsQueryable()
+                .Where(mappedFilter)
+                .Count()
+                .ShouldBe(1);
         }
     }
 }

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/Impl/SourceInjectedQuery.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/Impl/SourceInjectedQuery.cs
@@ -607,26 +607,25 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests.Impl
             destItem.DestValue.ShouldBe(sourceItem.SrcValue);
         }
 
-        [Fact]
+        [Fact(Skip="Conventions not available like this.")]
         public void Shoud_work_with_conventions()
         {
-            var mapper = new MapperConfiguration(cfg => cfg.AddConditionalObjectMapper()
-                .Where((s, d) => s.Name == d.Name + "Model" || s.Name + "Model" == d.Name)).CreateMapper();
+            //var mapper = new MapperConfiguration(cfg => cfg.AddConditionalObjectMapper()
+            //    .Where((s, d) => s.Name == d.Name + "Model" || s.Name + "Model" == d.Name)).CreateMapper();
 
 
-            IQueryable<Destination> result = _source.AsQueryable()
-                .UseAsDataSource(Mapper).For<Destination>()
-                .Where(s => s.DestValue > 6);
+            //IQueryable<Destination> result = _source.AsQueryable()
+            //    .UseAsDataSource(Mapper).For<Destination>()
+            //    .Where(s => s.DestValue > 6);
 
-            result.Count().ShouldBe(1);
-            result.Any(s => s.DestValue > 6).ShouldBeTrue();
+            //result.Count().ShouldBe(1);
+            //result.Any(s => s.DestValue > 6).ShouldBeTrue();
         }
 
         private static IMapper SetupAutoMapper()
         {
             var config = new MapperConfiguration(cfg =>
             {
-                cfg.CreateMissingTypeMaps = false;
                 cfg.CreateMap<User, UserModel>()
                 .ForMember(d => d.Id, opt => opt.MapFrom(s => s.UserId))
                 .ForMember(d => d.FullName, opt => opt.MapFrom(s => s.Name))

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.ForPath.Tests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.ForPath.Tests.cs
@@ -153,7 +153,7 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             var config = new MapperConfiguration(cfg =>
             {
                 cfg.AddExpressionMapping();
-                cfg.AddProfiles(typeof(ForPathCustomerProfile));
+                cfg.AddMaps(typeof(ForPathCustomerProfile));
             });
 
             mapper = config.CreateMapper();
@@ -231,6 +231,10 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
     {
         public ForPathCustomerProfile()
         {
+            /*Need a more meaningfull error message for when the Include and IncludeBase configurations have not been set up
+             CreateMap<DerivedDataModel, DerivedModel>()
+                .ForPath(d => d.Nested.NestedTitle, opt => opt.MapFrom(src => src.Title))
+                .ForPath(d => d.Nested.NestedTitle2, opt => opt.MapFrom(src => src.Title2));*/
             CreateMap<DataModel, RootModel>()
                 .Include<DerivedDataModel, DerivedModel>()
                 .ReverseMap();

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.ForPath.Tests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.ForPath.Tests.cs
@@ -30,6 +30,20 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         }
 
         [Fact]
+        public void Works_for_inherited_properties_on_base_types()
+        {
+            //Arrange
+            Expression<Func<RootModel, bool>> selection = s => ((DerivedModel)s).Nested.NestedTitle2 == "nested test";
+
+            //Act
+            Expression<Func<DataModel, bool>> selectionMapped = mapper.Map<Expression<Func<DataModel, bool>>>(selection);
+            List<DataModel> items = DataObjects.Where(selectionMapped).ToList();
+
+            //Assert
+            Assert.True(items.Count == 1);
+        }
+
+        [Fact]
         public void Works_for_top_level_string_member()
         {
             //Arrange
@@ -217,9 +231,15 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
     {
         public ForPathCustomerProfile()
         {
+            CreateMap<DataModel, RootModel>()
+                .Include<DerivedDataModel, DerivedModel>()
+                .ReverseMap();
+
             CreateMap<DerivedDataModel, DerivedModel>()
+                .IncludeBase<DataModel, RootModel>()
                 .ForPath(d => d.Nested.NestedTitle, opt => opt.MapFrom(src => src.Title))
-                .ForPath(d => d.Nested.NestedTitle2, opt => opt.MapFrom(src => src.Title2));
+                .ForPath(d => d.Nested.NestedTitle2, opt => opt.MapFrom(src => src.Title2))
+                .ReverseMap();
 
             CreateMap<OrderDto, Order>()
                 .ForPath(o => o.CustomerHolder.Customer.Name, o => o.MapFrom(s => s.Customer.Name))

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
@@ -19,6 +19,8 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
                 c.CreateMap<GarageModel, Garage>()
                     .ReverseMap()
                         .ForMember(d => d.Color, opt => opt.MapFrom(s => s.Truck.Color));
+                c.CreateMap<TruckModel, Truck>()
+                    .ReverseMap();
             });
 
             config.AssertConfigurationIsValid();
@@ -45,6 +47,8 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
                 c.CreateMap<GarageModel, Garage>()
                     .ReverseMap()
                         .ForMember(d => d.Color, opt => opt.MapFrom(s => s.Truck.Color));
+                c.CreateMap<TruckModel, Truck>()
+                    .ReverseMap();
             });
 
             config.AssertConfigurationIsValid();

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -262,7 +262,6 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             {
                 cfg.AddExpressionMapping();
                 cfg.CreateMap<Car, CarModel>();
-                cfg.CreateMissingTypeMaps = false;
             });
 
             var customMapper = config.CreateMapper();
@@ -276,7 +275,7 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
                     {
                         exception.InnerException.ShouldNotBeNull();
                         exception.InnerException.ShouldBeOfType<InvalidOperationException>();
-                        exception.InnerException.Message.ShouldContain("Mapper.CreateMap<CarModel, Car>", Case.Insensitive);
+                        exception.InnerException.Message.ShouldContain("CreateMap<CarModel, Car>", Case.Insensitive);
                     });
         }
 
@@ -693,6 +692,35 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             //Assert
             Assert.NotNull(dest);
         }
+
+        [Fact]
+        public void Can_map_expression_when_mapped_when_members_parent_is_a_method()
+        {
+            //Arrange
+            List<EmployeeEntity> empEntity = new List<EmployeeEntity>
+            {
+                new EmployeeEntity { Id = 1, Name = "Jean-Louis", Age = 39, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-1) } }.ToList() },
+                new EmployeeEntity { Id = 2, Name = "Jean-Paul", Age = 32, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-2) } }.ToList() },
+                new EmployeeEntity { Id = 3, Name = "Jean-Christophe", Age = 19, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-1) } }.ToList() },
+                new EmployeeEntity { Id = 4, Name = "Jean-Marie", Age = 27, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-3) } }.ToList() },
+                new EmployeeEntity { Id = 5, Name = "Jean-Marc", Age = 22, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-5) } }.ToList() },
+                new EmployeeEntity { Id = 5, Name = "Jean-Pierre", Age = 22, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-5) } }.ToList() },
+                new EmployeeEntity { Id = 6, Name = "Christophe", Age = 55, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-1) } }.ToList() },
+                new EmployeeEntity { Id = 7, Name = "Marc", Age = 23, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-2) } }.ToList() },
+                new EmployeeEntity { Id = 8, Name = "Paul", Age = 38, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-10) }, new EventEntity { EventType = "Stop", EventDate = DateTime.Today.AddYears(-1) } }.ToList() },
+                new EmployeeEntity { Id = 9, Name = "Jean", Age = 32, Events = new EventEntity[]{ new EventEntity { EventType = "Start", EventDate = DateTime.Today.AddYears(-10) }, new EventEntity { EventType = "Stop", EventDate = DateTime.Today.AddYears(-2) } }.ToList() },
+            };
+            Expression<Func<EmployeeModel, bool>> filter = emp =>
+                emp.Events.Any(e => e.EventType.Equals("Stop")) &&
+                emp.Events.First(e => e.EventType.Equals("Stop")).EventDate < DateTime.Today.AddYears(-1);
+
+            //Act
+            Expression<Func<EmployeeEntity, bool>> mappedFilter = mapper.MapExpression<Expression<Func<EmployeeEntity, bool>>>(filter);
+            List<EmployeeEntity> res = empEntity.AsQueryable().Where(mappedFilter).ToList();
+
+            //Assert
+            Assert.True(res.Count == 1);
+        }
         #endregion Tests
 
         private static void SetupAutoMapper()
@@ -700,7 +728,7 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             var config = new MapperConfiguration(cfg =>
             {
                 cfg.AddExpressionMapping();
-                cfg.AddProfiles(typeof(OrganizationProfile));
+                cfg.AddMaps(typeof(OrganizationProfile));
             });
 
             mapper = config.CreateMapper();
@@ -1097,6 +1125,35 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
     {
     }
 
+    internal class EmployeeEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public List<EventEntity> Events { get; set; }
+    }
+
+    internal class EventEntity
+    {
+        public string EventType { get; set; }
+        public DateTime EventDate { get; set; }
+    }
+
+
+    internal class EmployeeModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public List<EventModel> Events { get; set; }
+    }
+
+    internal class EventModel
+    {
+        public string EventType { get; set; }
+        public DateTime EventDate { get; set; }
+    }
+
     public class OrganizationProfile : Profile
     {
         public OrganizationProfile()
@@ -1198,7 +1255,11 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
                 .ReverseMap()
                 .ForMember(d => d.Count, opt => opt.MapFrom(s => s.Count));
 
-            CreateMissingTypeMaps = true;
+            CreateMap<Branch, BranchModel>();
+
+            CreateMap<EmployeeModel, EmployeeEntity>().ReverseMap();
+            CreateMap<EventModel, EventEntity>().ReverseMap();
+            //CreateMap<EventEntity, EmployeeModel>();
         }
     }
 


### PR DESCRIPTION
This PR is for issue #33, where it was raised that Type Binary and Conversion expressions are not mapped. The fix does require that the base types are mapped, and that the maps are included in whatever direction the map will be in.