### PR TITLE
feat: map an expression even if it would change the meaning of the operation.

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
@@ -1,18 +1,17 @@
-﻿using System;
+﻿using AutoMapper.Extensions.ExpressionMapping.Extensions;
+using AutoMapper.Extensions.ExpressionMapping.Structures;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using AutoMapper.Internal;
-using AutoMapper.Extensions.ExpressionMapping.Extensions;
-using AutoMapper.Extensions.ExpressionMapping.Structures;
 
 namespace AutoMapper.Extensions.ExpressionMapping
 {
     public class MapIncludesVisitor : XpressionMapperVisitor
     {
-        public MapIncludesVisitor(IMapper mapper, IConfigurationProvider configurationProvider, Dictionary<Type, Type> typeMappings)
-            : base(mapper, configurationProvider, typeMappings)
+        public MapIncludesVisitor(IMapper mapper, IConfigurationProvider configurationProvider, Dictionary<Type, Type> typeMappings, bool ignoreValidations)
+            : base(mapper, configurationProvider, typeMappings, ignoreValidations)
         {
         }
 


### PR DESCRIPTION
Creates a feature to allows map an expression even if it would change the meaning of the operation.

It's avoid the following:

System.InvalidOperationException: Rewriting child expression from type  to type is not allowed, because it would change the meaning of the operation. If this is intentional, override 'VisitUnary' and change it to allow this rewrite.