### PR TITLE
No Generics MapExpression extension and handling ExpressionType.TypeAs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.2-preview02</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
@@ -115,6 +115,8 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
                 case ExpressionType.Convert:
                     var ue = expression as UnaryExpression;
                     return GetParameterExpression(ue?.Operand);
+                case ExpressionType.TypeAs:
+                    return ((UnaryExpression)expression).Operand.GetParameterExpression();
                 case ExpressionType.MemberAccess:
                     return GetParameterExpression(((MemberExpression)expression).Expression);
                 case ExpressionType.Call:
@@ -138,16 +140,10 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
         /// </summary>
         /// <param name="expression"></param>
         /// <returns></returns>
-        public static Expression GetBaseOfMemberExpression(this MemberExpression expression)
-        {
-            switch (expression.Expression.NodeType)
-            {
-                case ExpressionType.MemberAccess:
-                    return GetBaseOfMemberExpression((MemberExpression)expression.Expression);
-                default:
-                    return expression.Expression;
-            }
-        }
+        public static Expression GetBaseOfMemberExpression(this MemberExpression expression) 
+            => expression.Expression.NodeType == ExpressionType.MemberAccess
+                ? GetBaseOfMemberExpression((MemberExpression)expression.Expression)
+                : expression.Expression;
 
         /// <summary>
         /// Adds member expressions to an existing expression.


### PR DESCRIPTION
1) Added "no-generics" IMapper.MapExpression extension method.
2) Updated GetParamterExpression to handle ExpressionType.TypeAs.