### PR TITLE
Fixes includes mapping broken by 3.0.4 (Fix setting the correct type …

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.4</VersionPrefix>
+    <VersionPrefix>3.0.5-preview01</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/MapIncludesVisitor.cs
@@ -16,6 +16,15 @@ namespace AutoMapper.Extensions.ExpressionMapping
         {
         }
 
+        protected override Expression VisitLambda<T>(Expression<T> node)
+        {
+            var ex = this.Visit(node.Body);
+
+            var mapped = Expression.Lambda(ex, node.GetDestinationParameterExpressions(this.InfoDictionary, this.TypeMappings));
+            this.TypeMappings.AddTypeMapping(ConfigurationProvider, node.Type, mapped.Type);
+            return mapped;
+        }
+
         protected override Expression VisitMember(MemberExpression node)
         {
             var parameterExpression = node.GetParameterExpression();

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -79,6 +79,20 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         }
 
         [Fact]
+        public void Map_collection_includes_with_flattened_string()
+        {
+            //Arrange
+            Expression<Func<UserModel, IEnumerable<string>>> selection = s => s.AccountModel.ThingModels.Select<ThingModel, string>(x => x.Color);
+
+            //Act
+            Expression<Func<User, IEnumerable<Car>>> selectionMapped = mapper.MapExpressionAsInclude<Expression<Func<User, IEnumerable<Car>>>>(selection);
+            List<Car> cars = Users.SelectMany(selectionMapped).ToList();
+
+            //Assert
+            Assert.True(cars.Count == 4);
+        }
+
+        [Fact]
         public void Map_includes_trim_string_nested_in_select_using_object()
         {
             //Arrange


### PR DESCRIPTION
Fixes includes mapping broken by 3.0.4 (Fix setting the correct type for `GroupBy.SelectMany()`).