### PR TITLE
Fixes mapping of flattened include expressions broken by 3.0.4.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.5-preview01</VersionPrefix>
+    <VersionPrefix>3.0.5</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -85,11 +85,11 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
             Expression<Func<UserModel, IEnumerable<string>>> selection = s => s.AccountModel.ThingModels.Select<ThingModel, string>(x => x.Color);
 
             //Act
-            Expression<Func<User, IEnumerable<Car>>> selectionMapped = mapper.MapExpressionAsInclude<Expression<Func<User, IEnumerable<Car>>>>(selection);
-            List<Car> cars = Users.SelectMany(selectionMapped).ToList();
+            Expression<Func<User, object>> selectionMapped = mapper.MapExpressionAsInclude<Expression<Func<User, object>>>(selection);
+            List<object> listOfCarLists = Users.Select(selectionMapped).ToList();
 
             //Assert
-            Assert.True(cars.Count == 4);
+            Assert.True(listOfCarLists.Count == 2);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes mapping of flattened include expressions broken by 3.0.4 (ArgumentException "type1" cannot be used for return type "type2").