### PR TITLE
Remove reference to obsolete PrimitiveHelper.IsListOrDictionaryType.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.1.1-preview01</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/src/AutoMapper.Extensions.ExpressionMapping/PrimitiveExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/PrimitiveExtensions.cs
@@ -37,9 +37,6 @@ namespace AutoMapper.Extensions.ExpressionMapping
         public static bool IsListType(this Type type)
             => PrimitiveHelper.IsListType(type);
 
-        public static bool IsListOrDictionaryType(this Type type)
-            => PrimitiveHelper.IsListOrDictionaryType(type);
-
         public static bool IsDictionaryType(this Type type)
             => PrimitiveHelper.IsDictionaryType(type);
 


### PR DESCRIPTION
Remove reference to obsolete `PrimitiveHelper.IsListOrDictionaryType()`.