### PR TITLE
Fix for: "Argument types do not match" exception when mapping a member init expression.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.1.1</VersionPrefix>
+    <VersionPrefix>3.1.2-preview01</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>

--- a/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Extensions/VisitorExtensions.cs
@@ -82,6 +82,9 @@ namespace AutoMapper.Extensions.ExpressionMapping.Extensions
 
         public static Expression ConvertTypeIfNecessary(this Expression expression, Type memberType)
         {
+            if (memberType == expression.Type)
+                return expression;
+
             expression = expression.GetUnconvertedMemberExpression();
             if (memberType != expression.Type)
                 return Expression.Convert(expression, memberType);

--- a/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
@@ -167,6 +167,7 @@ namespace AutoMapper.Extensions.ExpressionMapping
 
         private MemberBinding DoBind(PropertyMap propertyMap, Expression initial, Expression mapped)
         {
+            mapped = mapped.ConvertTypeIfNecessary(propertyMap.SourceMember.GetMemberType());
             this.TypeMappings.AddTypeMapping(ConfigurationProvider, initial.Type, mapped.Type);
             return Expression.Bind(propertyMap.SourceMember, mapped);
         }

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapperTests.cs
@@ -430,13 +430,39 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         }
 
         [Fact]
-        public void Map_MemberInit()
+        public void Map_member_init()
         {
             //Arrange
             Expression<Func<ThingModel, ThingModel>> selection = s => new ThingModel { Car = s.Car };
 
             //Act
             Expression<Func<Thing, Thing>> selectionMapped = mapper.MapExpression<Expression<Func<Thing, Thing>>>(selection);
+
+            //Assert
+            Assert.NotNull(selectionMapped);
+        }
+
+        [Fact]
+        public void Map_member_init_when_source_member_is_enum_and_destination_member_is_int()
+        {
+            //Arrange
+            Expression<Func<ModelWithEnumMembers, ModelWithEnumMembers>> selection = m => new ModelWithEnumMembers { EnumValue = m.EnumValue };
+
+            //Act
+            var selectionMapped = mapper.MapExpression<Expression<Func<EntityWithIntMembers, EntityWithIntMembers>>>(selection);
+
+            //Assert
+            Assert.NotNull(selectionMapped);
+        }
+
+        [Fact]
+        public void Map_member_init_when_source_member_is_nullable_enum_and_destination_member_is_int()
+        {
+            //Arrange
+            Expression<Func<ModelWithEnumMembers, ModelWithEnumMembers>> selection = m => new ModelWithEnumMembers { NullableEnumValue = m.NullableEnumValue };
+
+            //Act
+            var selectionMapped = mapper.MapExpression<Expression<Func<EntityWithIntMembers, EntityWithIntMembers>>>(selection);
 
             //Assert
             Assert.NotNull(selectionMapped);
@@ -842,9 +868,6 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         [Fact]
         public void Can_map_expression_with_condittional_logic_while_deflattening()
         {
-            /*
-             CreateMap<TestEntity, TestDTO>()
-                .ForMember(dst => dst.NestedClass, opt => opt.MapFrom(src => src.ConditionField == 1 ? src : default));*/
             Expression<Func<TestDTO, bool>> expr = x => x.NestedClass.NestedField == 1;
 
             var mappedExpression = mapper.MapExpression<Expression<Func<TestEntity, bool>>>(expr);
@@ -1303,6 +1326,24 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
         public int? NestedField { get; set; }
     }
 
+    public enum TestEnum
+    {
+        Prop0 = 0,
+        Prop1 = 1
+    }
+
+    public class EntityWithIntMembers
+    {
+        public int IntValue { get; set; }
+        public int OtherIntValue { get; set; }
+    }
+
+    public class ModelWithEnumMembers
+    {
+        public TestEnum EnumValue { get; set; }
+        public TestEnum? NullableEnumValue { get; set; }
+    }
+
     public class OrganizationProfile : Profile
     {
         public OrganizationProfile()
@@ -1415,6 +1456,10 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
 
             CreateMap<TestEntity, TestDTONestedClass>()
                 .ForMember(dst => dst.NestedField, opt => opt.MapFrom(src => (int?)src.ToBeNestedField));
+
+            CreateMap<EntityWithIntMembers, ModelWithEnumMembers>()
+                .ForMember(e => e.EnumValue, o => o.MapFrom(s => (TestEnum)s.IntValue))
+                .ForMember(e => e.NullableEnumValue, o => o.MapFrom(s => ((TestEnum)s.OtherIntValue) as TestEnum?));
         }
     }
 


### PR DESCRIPTION
Fix for: "Argument types do not match" exception when mapping a member init expression.