### PR TITLE
Fix exceptions with generic source types

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/ExpressionMapper.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/ExpressionMapper.cs
@@ -173,7 +173,7 @@ namespace AutoMapper.Mappers
                     from t in expression.Parameters
                     let sourceParamType = t.Type
                     from destParamType in _destSubTypes.Where(dt => dt != sourceParamType)
-                    let a = destParamType.IsGenericType() ? destParamType.GetTypeInfo().GenericTypeArguments[0] : destParamType
+                    let a = destParamType.IsEnumerableType(out var itemType) ? itemType : destParamType
                     let typeMap = _configurationProvider.ResolveTypeMap(a, sourceParamType)
                     where typeMap != null
                     let oldParam = t

--- a/src/AutoMapper.Extensions.ExpressionMapping/ExpressionMapper.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/ExpressionMapper.cs
@@ -173,7 +173,7 @@ namespace AutoMapper.Mappers
                     from t in expression.Parameters
                     let sourceParamType = t.Type
                     from destParamType in _destSubTypes.Where(dt => dt != sourceParamType)
-                    let a = destParamType.IsEnumerableType(out var itemType) ? itemType : destParamType
+                    let a = destParamType.IsEnumerableType() ? destParamType.GetGenericElementType() : destParamType
                     let typeMap = _configurationProvider.ResolveTypeMap(a, sourceParamType)
                     where typeMap != null
                     let oldParam = t

--- a/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
@@ -172,13 +172,7 @@ namespace AutoMapper
         public static Type GetGenericElementType(this Type type)
             => type.HasElementType ? type.GetElementType() : type.GetTypeInfo().GenericTypeArguments[0];
 
-        public static bool IsEnumerableType(this Type type, out Type itemType)
-        {
-            itemType = type.GetInterfaces()
-                .FirstOrDefault(t => t.GetGenericTypeDefinitionIfGeneric() == typeof(IEnumerable<>))
-                ?.GetGenericArguments()[0];
-
-            return itemType != null;
-        }
+        public static bool IsEnumerableType(this Type type) =>
+            type.IsGenericType && typeof(System.Collections.IEnumerable).IsAssignableFrom(type);
     }
 }

--- a/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/TypeExtensions.cs
@@ -171,5 +171,14 @@ namespace AutoMapper
 
         public static Type GetGenericElementType(this Type type)
             => type.HasElementType ? type.GetElementType() : type.GetTypeInfo().GenericTypeArguments[0];
+
+        public static bool IsEnumerableType(this Type type, out Type itemType)
+        {
+            itemType = type.GetInterfaces()
+                .FirstOrDefault(t => t.GetGenericTypeDefinitionIfGeneric() == typeof(IEnumerable<>))
+                ?.GetGenericArguments()[0];
+
+            return itemType != null;
+        }
     }
 }

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingWithUseAsDataSource.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/ExpressionMappingWithUseAsDataSource.cs
@@ -42,6 +42,35 @@
             result.ShouldAllBe(expOverDTO);
         }
 
+        [Fact]
+        public void Should_Map_From_Generic_Type()
+        {
+            // Arrange
+            var mapper = CreateMapper();
+
+            var models = new List<GenericModel<bool>>()
+            {
+                new GenericModel<bool> {ABoolean = true},
+                new GenericModel<bool> {ABoolean = false},
+                new GenericModel<bool> {ABoolean = true},
+                new GenericModel<bool> {ABoolean = false}
+            };
+
+            var queryable = models.AsQueryable();
+
+            Expression<Func<DTO, bool>> expOverDTO = (dto) => dto.Nested.AnotherBoolean;
+
+            // Act
+            var q = queryable.UseAsDataSource(mapper).For<DTO>().Where(expOverDTO);
+
+            var result = q.ToList();
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Count.ShouldBe(2);
+            result.ShouldAllBe(expOverDTO);
+        }
+
         private static IMapper CreateMapper()
         {
             var mapperConfig = new MapperConfiguration(cfg =>
@@ -52,7 +81,10 @@
                     .ForMember(d => d.AnotherBoolean, opt => opt.MapFrom(s => s.ABoolean));
                 cfg.CreateMap<DTO, Model>()
                     .ForMember(d => d.ABoolean, opt => opt.MapFrom(s => s.Nested.AnotherBoolean));
-
+                cfg.CreateMap<GenericModel<bool>, DTO>()
+                    .ForMember(d => d.Nested, opt => opt.MapFrom(s => s));
+                cfg.CreateMap<GenericModel<bool>, DTO.DTONested>()
+                    .ForMember(d => d.AnotherBoolean, opt => opt.MapFrom(s => s.ABoolean));
             });
 
             var mapper = mapperConfig.CreateMapper();
@@ -72,6 +104,12 @@
         private class Model
         {
             public bool ABoolean { get; set; }
+        }
+
+
+        private class GenericModel<T>
+        {
+            public T ABoolean { get; set; }
         }
     }
 }


### PR DESCRIPTION
Today I ran into issues when mapping generic source types with `UseAsDataSource()`. I noticed `ExpressionMapper.VisitAllParametersExpression` was substituting the source type for it's generic argument when trying to find a match, which of course breaks the matching.

I changed the method to only take the generic type argument if the type implements `IEnumerable<>`, because I'm assuming what this logic is for. All tests still pass, so I'm assuming all is still fine. I also added a test which breaks without this change.