### PR TITLE
Support generic type argument inference when mapping method calls

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/ExpressionMapper.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/ExpressionMapper.cs
@@ -68,7 +68,10 @@ namespace AutoMapper.Mappers
                 if (!node.Method.IsGenericMethod)
                     return node;
                 var convertedArguments = Visit(node.Arguments);
-                var convertedMethodArgumentTypes = node.Method.GetGenericArguments().Select(t => GetConvertingTypeIfExists(node.Arguments, t, convertedArguments)).ToArray();
+                var genericMethodCall = node.Method.GetGenericMethodDefinition();
+                var convertedMethodArgumentTypes = TypeMatcher.InferGenericArguments(genericMethodCall,
+                    convertedArguments.Select(expr => expr.Type));
+
                 var convertedMethodCall = node.Method.GetGenericMethodDefinition().MakeGenericMethod(convertedMethodArgumentTypes);
                 return Call(convertedMethodCall, convertedArguments);
             }

--- a/src/AutoMapper.Extensions.ExpressionMapping/TypeMatcher.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/TypeMatcher.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace AutoMapper.Extensions.ExpressionMapping
+{
+    public static class TypeMatcher
+    {
+        public static Type[] InferGenericArguments(MethodInfo method, IEnumerable<Type> constructedArgumentTypes)
+        {
+            return new TypeInference(method, constructedArgumentTypes).Result;
+        }
+
+        private class TypeInference
+        {
+            public Type[] Result { get; }
+            private readonly HashSet<Type> _matched;
+
+            public TypeInference(MethodInfo method, IEnumerable<Type> constructedArgumentTypes)
+            {
+                Result = method.GetGenericArguments();
+                _matched = new HashSet<Type>();
+
+                foreach (var pair in constructedArgumentTypes.Zip(method.GetParameters().Select(p => p.ParameterType),
+                    (arg, param) => new {Argument = arg, Parameter = param}))
+                {
+                    MatchGenericParameter(pair.Argument, pair.Parameter);
+                    if (_matched.Count == Result.Length) return;
+                }
+
+                throw new Exception($"Failed to infer generic arguments for {method} using argument types {string.Join(", ", constructedArgumentTypes)}.");
+            }
+
+            private void MatchGenericParameter(Type argumentType, Type parameterType)
+            {
+                if (parameterType.IsGenericParameter && _matched.Add(parameterType))
+                {
+                    for (var i = 0; i < Result.Length; i++)
+                    {
+                        if (Result[i] == parameterType)
+                        {
+                            Result[i] = argumentType;
+                            return;
+                        }
+                    }
+                }
+                else if (parameterType.IsGenericType && argumentType.IsGenericType)
+                {
+                    foreach (var pair in argumentType.GetGenericArguments().Zip(parameterType.GetGenericArguments(),
+                        (arg, param) => new {Argument = arg, Parameter = param}))
+                    {
+                        MatchGenericParameter(pair.Argument, pair.Parameter);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/MappingToNullablePropertyUsingUseAsDataSource.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/MappingToNullablePropertyUsingUseAsDataSource.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Shouldly;
+using Xunit;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
+{
+    public class MappingToNullablePropertyUsingUseAsDataSource
+    {
+        [Fact]
+        public void When_Apply_OrderBy_Clause_Over_Queryable_As_Data_Source()
+        {
+            // Arrange
+            var mapper = CreateMapper();
+
+            var models = new List<Model>()
+            {
+                new Model {Value = 1},
+                new Model {Value = 2}
+            };
+
+            var queryable = models.AsQueryable();
+
+            Expression<Func<DTO, int?>> dtoPropertySelector = (dto) => dto.Value;
+
+            // Act
+            var result = queryable.UseAsDataSource(mapper).For<DTO>().OrderBy(dtoPropertySelector).ToList();
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void When_Apply_Where_Clause_Over_Queryable_As_Data_Source()
+        {
+            // Arrange
+            var mapper = CreateMapper();
+
+            var models = new List<Model> {new Model {Value = 1}, new Model {Value = 2}};
+
+            var queryable = models.AsQueryable();
+
+            Expression<Func<DTO, bool>> dtoPropertyFilter = (dto) => dto.Value == 1;
+
+            // Act
+            var result = queryable.UseAsDataSource(mapper).For<DTO>().Where(dtoPropertyFilter).ToList();
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void When_Apply_Where_Clause_Over_Queryable_As_Data_Source_DateTimeOffset()
+        {
+            // Arrange
+            var mapper = CreateMapper();
+
+            var models = new List<Model>
+            {
+                new Model {Value = 1, Timestamp = DateTimeOffset.Now},
+                new Model {Value = 2, Timestamp = DateTimeOffset.Now.AddDays(1)}
+            };
+
+            var queryable = models.AsQueryable();
+
+            Expression<Func<DTO, bool>> dtoPropertyFilter = (dto) => dto.Timestamp > DateTimeOffset.Now;
+
+            // Act
+            var result = queryable.UseAsDataSource(mapper).For<DTO>().Where(dtoPropertyFilter).ToList();
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Count.ShouldBe(1);
+        }
+
+        private static IMapper CreateMapper()
+        {
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Model, DTO>();
+            });
+
+            var mapper = mapperConfig.CreateMapper();
+            return mapper;
+        }
+
+        private class Model
+        {
+            public DateTimeOffset Timestamp { get; set; }
+            public int Value { get; set; }
+        }
+
+        private class DTO
+        {
+            public DateTimeOffset? Timestamp { get; set; }
+            public int? Value { get; set; }
+        }
+
+    }
+}


### PR DESCRIPTION
This is mostly a proof of concept. It works, passes all unit tests and passes a few new unit tests. It does solve #97, although it doesn't change anything about the exception that's thrown from the example using `Mapper.MapExpression()` that's used there.

I guess that in some sense it's an improvement over `GetConvertingTypeIfExists` since it infers the types from the generic type parameters instead of trying to match it to a single target type.

Let me know what you think.