### PR TITLE
avoid turning MemberAccess expressions of literal types into Constants

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/XpressionMapperVisitor.cs
@@ -57,6 +57,9 @@ namespace AutoMapper.Extensions.ExpressionMapping
                 var baseExpression = node.GetBaseOfMemberExpression();
                 if (baseExpression?.NodeType == ExpressionType.Constant)
                 {
+                    if (node.Type.IsLiteralType())
+                        return node;
+
                     return this.Visit
                     (
                         Expression.Constant

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
@@ -161,10 +161,35 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
 
             //Act
             var mappedfilter = mapper.MapExpression<Expression<Func<Garage, bool>>>(filter);
-            var mappedrhs = ((BinaryExpression)mappedfilter.Body).Right;
 
             //Assert
             Assert.NotNull(mappedfilter);
+        }
+
+        [Fact]
+        public void Ignore_member_expressions_where_type_is_literal_and_node_type_is_constant()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<GarageModel, Garage>()
+                    .ReverseMap()
+                        .ForMember(d => d.Color, opt => opt.MapFrom(s => s.Truck.Color));
+                c.CreateMap<TruckModel, Truck>()
+                    .ReverseMap();
+            });
+
+            config.AssertConfigurationIsValid();
+            var mapper = config.CreateMapper();
+
+            GarageModel garage = new GarageModel { Color = "Blue", Truck = new TruckModel { Color = "Red", Year = 1999 } };
+            Expression<Func<GarageModel, bool>> filter = m => m.Color == garage.Color;
+
+            //Act
+            var mappedFilter = mapper.MapExpression<Expression<Func<Garage, bool>>>(filter);
+            var mappedrhs = ((BinaryExpression)mappedFilter.Body).Right;
+
+            //Assert
             Assert.Equal(ExpressionType.MemberAccess, mappedrhs.NodeType);
         }
 

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/XpressionMapper.Structs.Tests.cs
@@ -161,9 +161,11 @@ namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
 
             //Act
             var mappedfilter = mapper.MapExpression<Expression<Func<Garage, bool>>>(filter);
+            var mappedrhs = ((BinaryExpression)mappedfilter.Body).Right;
 
             //Assert
             Assert.NotNull(mappedfilter);
+            Assert.Equal(ExpressionType.MemberAccess, mappedrhs.NodeType);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #122 by checking if member expressions are literal types, in which case they don't need mapping. This avoids creating a constant (which can't be lifted to an SQL parameter) from a member access expression such as a local variable reference the expression closes over (which can). Adds a test assertion to confirm that mapping a literal type in this way doesn't change the type of the node.