### PR TITLE
Fix enumerator not disposed when arbitrary projection is enumerated

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
@@ -111,9 +111,9 @@ namespace AutoMapper.Extensions.ExpressionMapping.Impl
                     destResult = (IQueryable<TDestination>)GetMapExpressions(queryExpressions).Aggregate(sourceResult, Select);
                 }
                 // case #2: query is arbitrary ("manual") projection
-                // exaple: users.UseAsDataSource().For<UserDto>().Select(user => user.Age).ToList()
+                // example: users.UseAsDataSource().For<UserDto>().Select(user => user.Age).ToList()
                 // in case an arbitrary select-statement is enumerated, we do not need to map the expression at all
-                // and cann safely return it
+                // and can safely return it
                 else if (IsProjection(resultType, sourceExpression))
                 {
                     var sourceResult = _dataSource.Provider.CreateQuery(sourceExpression);

--- a/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
@@ -117,15 +117,14 @@ namespace AutoMapper.Extensions.ExpressionMapping.Impl
                 else if (IsProjection(resultType, sourceExpression))
                 {
                     var sourceResult = _dataSource.Provider.CreateQuery(sourceExpression);
-                    var enumerator = sourceResult.GetEnumerator();
                     var elementType = ElementTypeHelper.GetElementType(typeof(TResult));
                     var constructorInfo = typeof(List<>).MakeGenericType(elementType).GetDeclaredConstructor(new Type[0]);
                     if (constructorInfo != null)
                     {
                         var listInstance = (IList)constructorInfo.Invoke(null);
-                        while (enumerator.MoveNext())
+                        foreach (var element in sourceResult)
                         {
-                            listInstance.Add(enumerator.Current);
+                            listInstance.Add(element);
                         }
                         destResult = listInstance;
                     }


### PR DESCRIPTION
Fixes #133

Let's directly `foreach` the enumerable, which automatically disposes the enumerator.

I have added a test which fails for v5.0.0 (and v4.1.3) and passes with the new changes: `Should_dispose_enumerator_when_arbitrary_projection_is_enumerated`

# Backport request

Kindly backport to 4.x, so that this can be used in the same project that depends on AutoMapper.Collection, which does not support AutoMapper 11.x.
Reference: https://github.com/AutoMapper/AutoMapper.Collection/issues/162