### PR TITLE
[v4.1.4] Fix enumerator not disposed when arbitrary projection is enumerated

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
@@ -107,15 +107,14 @@ namespace AutoMapper.Extensions.ExpressionMapping.Impl
                 else if (IsProjection(resultType, sourceExpression))
                 {
                     var sourceResult = _dataSource.Provider.CreateQuery(sourceExpression);
-                    var enumerator = sourceResult.GetEnumerator();
                     var elementType = ElementTypeHelper.GetElementType(typeof(TResult));
                     var constructorInfo = typeof(List<>).MakeGenericType(elementType).GetDeclaredConstructor(new Type[0]);
                     if (constructorInfo != null)
                     {
                         var listInstance = (IList)constructorInfo.Invoke(null);
-                        while (enumerator.MoveNext())
+                        foreach (var element in sourceResult)
                         {
-                            listInstance.Add(enumerator.Current);
+                            listInstance.Add(element);
                         }
                         destResult = listInstance;
                     }

--- a/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/Impl/SourceInjectedQueryProvider.cs
@@ -101,9 +101,9 @@ namespace AutoMapper.Extensions.ExpressionMapping.Impl
                     destResult = (IQueryable<TDestination>)mapExpressions.Aggregate(sourceResult, Select);
                 }
                 // case #2: query is arbitrary ("manual") projection
-                // exaple: users.UseAsDataSource().For<UserDto>().Select(user => user.Age).ToList()
+                // example: users.UseAsDataSource().For<UserDto>().Select(user => user.Age).ToList()
                 // in case an arbitrary select-statement is enumerated, we do not need to map the expression at all
-                // and cann safely return it
+                // and can safely return it
                 else if (IsProjection(resultType, sourceExpression))
                 {
                     var sourceResult = _dataSource.Provider.CreateQuery(sourceExpression);


### PR DESCRIPTION
Fixes #133 

Backport of #132, so that this can be used in a project that depends on AutoMapper.Collection 7.0.x, which does not support AutoMapper 11.x.
Reference: https://github.com/AutoMapper/AutoMapper.Collection/issues/162