### PR TITLE
Fixes Issue #152. EF.Property not mapped correctly.

### DIFF
--- a/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
+++ b/src/AutoMapper.Extensions.ExpressionMapping/PrependParentNameVisitor.cs
@@ -18,6 +18,18 @@ namespace AutoMapper.Extensions.ExpressionMapping
         public string ParentFullName { get; }
         public Expression NewParameter { get; }
 
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (object.ReferenceEquals(CurrentParameter, node))
+            {
+                return string.IsNullOrEmpty(ParentFullName)
+                        ? NewParameter
+                        : ExpressionHelpers.MemberAccesses(ParentFullName, NewParameter);
+            }
+
+            return base.VisitParameter(node);
+        }
+
         protected override Expression VisitTypeBinary(TypeBinaryExpression node)
         {
             if (!(node.Expression is ParameterExpression))

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/CanMapParameterBodyFromChildReferenceWithoutMemberExpression.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/CanMapParameterBodyFromChildReferenceWithoutMemberExpression.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
+{
+    public class CanMapParameterBodyFromChildReferenceWithoutMemberExpression
+    {
+        [Fact]
+        public void Can_map_parameter_body_from_child_reference_without_member_expression()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<TestCategory, TestProductDTO>()
+                   .ForMember(p => p.Brand, c => c.MapFrom(p => EF.Property<int>(p, "BrandId"))); ;
+
+                c.CreateMap<TestProduct, TestProductDTO>()
+                  .IncludeMembers(p => p.Category);
+            });
+
+            config.AssertConfigurationIsValid();
+            var mapper = config.CreateMapper();
+
+            var products = new List<TestProduct>() {
+                new TestProduct { }
+              }.AsQueryable();
+
+            //Act
+            Expression<Func<TestProductDTO, bool>> expr = x => x.Brand == 2;
+            var mappedExpression = mapper.MapExpression<Expression<Func<TestProduct, bool>>>(expr);
+
+            //Assert
+            Assert.Equal("x => (Convert(Property(x.Category, \"BrandId\"), Int32) == 2)", mappedExpression.ToString());
+        }
+
+        public class TestCategory
+        {
+            // Has FK BrandId
+        }
+        public class TestProduct
+        {
+            public TestCategory? Category { get; set; }
+        }
+
+        public class TestProductDTO
+        {
+            public int Brand { get; set; }
+        }
+    }
+}

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/CanMapParameterBodyWithoutMemberExpression.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/CanMapParameterBodyWithoutMemberExpression.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
+{
+    public class CanMapParameterBodyWithoutMemberExpression
+    {
+        [Fact]
+        public void Can_map_parameter_body_without_member_expression()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<TestProduct, TestProductDTO>()
+                  .ForMember(p => p.Brand, c => c.MapFrom(p => EF.Property<int>(p, "BrandId")));
+            });
+
+            config.AssertConfigurationIsValid();
+            var mapper = config.CreateMapper();
+
+            var products = new List<TestProduct>() {
+                new TestProduct { }
+              }.AsQueryable();
+
+            //Act
+            Expression<Func<TestProductDTO, bool>> expr = x => x.Brand == 2;
+            var mappedExpression = mapper.MapExpression<Expression<Func<TestProduct, bool>>>(expr);
+
+            //Assert
+            Assert.Equal("x => (Convert(Property(x, \"BrandId\"), Int32) == 2)", mappedExpression.ToString());
+        }
+
+        public class TestProduct
+        {
+            // Empty, has shadow key named BrandId
+        }
+
+        public class TestProductDTO
+        {
+            public int Brand { get; set; }
+        }
+    }
+}

--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/EF.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/EF.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests
+{
+    internal class EF
+    {
+        internal static object Property<T>(object p, string v)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes Issue #152. `EF.Property` not mapped correctly.