### PR TITLE
Add test for collection aggregate mapping issue

### DIFF
--- a/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/MappingCollectionAggregateTests.cs
+++ b/tests/AutoMapper.Extensions.ExpressionMapping.UnitTests/MappingCollectionAggregateTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using AutoMapper.Execution;
+using AutoMapper.Internal;
+using Xunit;
+
+namespace AutoMapper.Extensions.ExpressionMapping.UnitTests;
+
+public class MappingCollectionAggregateTests : AutoMapperSpecBase
+{
+    private IQueryable<Source> _sources;
+
+    public class Source
+    {
+        public ICollection<Item> Items { get; set; } = new List<Item> { new Item { Timestamp = DateTime.Now } };
+    }
+
+    public class Item
+    {
+        public DateTime Timestamp { get; set; }
+    }
+
+    public class Dest
+    {
+        public DateTime? ItemsTimestampMax { get; set; }
+    }
+
+    protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+    {
+        cfg.CreateMap<Source, Dest>()
+            .ForMember(dst => dst.ItemsTimestampMax, opt => opt.MapFrom(src => src.Items.Max(x => x.Timestamp)));
+
+        cfg.Internal().ForAllPropertyMaps(
+            p => p.SourceType == typeof(DateTimeOffset) && p.DestinationType == typeof(DateTimeOffset?) &&
+                p.CustomMapExpression != null, (pMap, _) =>
+            {
+                var resolver = new ExpressionResolver(Expression.Lambda(
+                    Expression.Convert(pMap.CustomMapExpression.Body, typeof(DateTimeOffset?)),
+                    pMap.CustomMapExpression.Parameters));
+
+                pMap.SetResolver(resolver);
+            });
+    });
+
+    protected override void Because_of()
+    {
+        _sources = new[] { new Source() }.AsQueryable();
+    }
+
+    [Fact]
+    public void Maps_Date_Filter()
+    {
+        _sources.UseAsDataSource(Configuration).For<Dest>()
+            .Where(d => d.ItemsTimestampMax > DateTime.Today).ToList();
+    }
+
+    [Fact]
+    public void Maps_Date_Value_Filter()
+    {
+        _sources.UseAsDataSource(Configuration).For<Dest>()
+            .Where(d => d.ItemsTimestampMax.Value.Date == DateTime.Today).ToList();
+    }
+}


### PR DESCRIPTION
This PR relates to AutoMapper/AutoMapper#4329. While the bug is in AutoMapper, the result is quite unexpected. The first test will pass, but the second test throws the following exception:
```
System.InvalidOperationException
variable 'd' of type 'AutoMapper.Extensions.ExpressionMapping.UnitTests.MappingCollectionAggregateTests+Dest' referenced from scope '', but it is not defined
   at System.Linq.Expressions.Compiler.VariableBinder.Reference(ParameterExpression node, VariableStorageKind storage)
   at System.Linq.Expressions.Compiler.VariableBinder.VisitParameter(ParameterExpression node)
   at System.Linq.Expressions.ParameterExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.MemberExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.MemberExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.MemberExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.ExpressionVisitor.VisitBinary(BinaryExpression node)
   at System.Linq.Expressions.BinaryExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.ExpressionVisitor.Visit(ReadOnlyCollection`1 nodes)
   at System.Linq.Expressions.Compiler.VariableBinder.VisitLambda[T](Expression`1 node)
   at System.Linq.Expressions.Expression`1.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Dynamic.Utils.ExpressionVisitorUtils.VisitArguments(ExpressionVisitor visitor, IArgumentProvider nodes)
   at System.Linq.Expressions.ExpressionVisitor.VisitMethodCall(MethodCallExpression node)
   at System.Linq.Expressions.MethodCallExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Dynamic.Utils.ExpressionVisitorUtils.VisitArguments(ExpressionVisitor visitor, IArgumentProvider nodes)
   at System.Linq.Expressions.ExpressionVisitor.VisitMethodCall(MethodCallExpression node)
   at System.Linq.Expressions.MethodCallExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.ExpressionVisitor.Visit(ReadOnlyCollection`1 nodes)
   at System.Linq.Expressions.Compiler.VariableBinder.VisitLambda[T](Expression`1 node)
   at System.Linq.Expressions.Expression`1.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.Compiler.VariableBinder.Visit(Expression node)
   at System.Linq.Expressions.Compiler.LambdaCompiler.Compile(LambdaExpression lambda)
   at System.Linq.Expressions.Expression`1.Compile()
   at System.Linq.EnumerableQuery`1.GetEnumerator()
   at System.Linq.EnumerableQuery`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator()
   at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at AutoMapper.Extensions.ExpressionMapping.Impl.SourceSourceInjectedQuery`2.GetEnumerator() in C:\Users\michaelc\Documents\Projects\AutoMapper.Extensions.ExpressionMapping\src\AutoMapper.Extensions.ExpressionMapping\Impl\SourceInjectedQuery.cs:line 63
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at AutoMapper.Extensions.ExpressionMapping.UnitTests.MappingCollectionAggregateTests.Maps_Date_Value_Filter() in C:\Users\michaelc\Documents\Projects\AutoMapper.Extensions.ExpressionMapping\tests\AutoMapper.Extensions.ExpressionMapping.UnitTests\MappingCollectionAggregateTests.cs:line 62
```

I'm not sure if AutoMapper or AutoMapper.Extensions.ExpressionMapping is to blame for this rather inconvenient exception, but using the workaround described in the AutoMapper issue does resolve this problem as well. Nevertheless it would be nice if AutoMapper.Extensions.ExpressionMapping could fail early while building the expression, with a proper reason why it can't resolve the correct expression. If AutoMapper is still to blame for this part as well, then maybe a unit test can be produced to prevent future regressions in that area.